### PR TITLE
centering price boxes if less than 3

### DIFF
--- a/wp-content/themes/Parallax-One/sections/parallax_one_prices_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_prices_section.php
@@ -70,7 +70,7 @@
 <?php 
                   // the remaining elements after full row (e.g. 4th and 5th after row of 3 columns)
                   // should be centered
-                  if (($counter + 1) > (round(sizeof($prices_decoded) / 3) * 3)) {
+                  if (($counter + 1) > (round(sizeof($prices_decoded) / 3) * 3) || sizeof($prices_decoded) < 3) {
                     echo 'style="float: none;"';
                   }
 ?>


### PR DESCRIPTION
Issue:

http://4water.org/cardiff/dance/
![center-prices](https://cloud.githubusercontent.com/assets/3256703/25578957/4d9b7934-2e6b-11e7-9da5-987756dbdfd1.png)

Not completely sure this would solve this (don't have project running locally, so did not test) . But adding `style="float: none;"` should center the price boxes (tested by modifying the HTML browser). Could someone (is it only you here Laci? :-) ) please try this before pulling in?

Thanks