### PR TITLE
Rewrite rule dance <-> salsa for Lund

### DIFF
--- a/htaccess-production.txt
+++ b/htaccess-production.txt
@@ -12,10 +12,11 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^ - [L]
 # changed per https://paulund.co.uk/wordpress-multisite-nested-paths
-# Berlin, Lyon, Cardiff: dance -> salsa
+# Berlin, Lyon, Cardiff, Lund: dance -> salsa
 RewriteRule ^([_0-9a-zA-Z-]+/)?berlin/dance(/.*)?$ berlin/salsa$2 [R=301,L]
 RewriteRule ^([_0-9a-zA-Z-]+/)?lyon/dance(/.*)?$ lyon/salsa$2 [R=301,L]
 RewriteRule ^([_0-9a-zA-Z-]+/)?cardiff/dance(/.*)?$ cardiff/salsa$2 [R=301,L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?lund/dance(/.*)?$ lund/salsa$2 [R=301,L]
 # All the rest: salsa -> dance
 RewriteRule ^([_0-9a-zA-Z-]+/)?copenhagen/salsa(/.*)?$ copenhagen/dance$2 [R=301,L]
 RewriteRule ^([_0-9a-zA-Z-]+/)?glasgow/salsa(/.*)?$ glasgow/dance$2 [R=301,L]


### PR DESCRIPTION
This is the only change in the code required when we add a city (as we now add Salsa4Water Lund).

All would work even without, but we decided in the past that it's a good improvement, because of our interchangeability between Dance4Water and Salsa4Water for many cities. With this rule, whoever enters `4water.org/lund/dance` in the browser, will get redirected to `4water.org/lund/salsa`, which is Lund's URL of choice.

P.S. I updated `.htaccess` on production already