### PR TITLE
Fix margin in image section

### DIFF
--- a/wp-content/themes/Parallax-One/style.css
+++ b/wp-content/themes/Parallax-One/style.css
@@ -1459,6 +1459,12 @@ section#image-section {
 	width: 100%;
 }
 
+@media only screen and (max-width: 800px) {
+	#image-section div.subtitle-above {
+		margin: 0 40px;
+	}
+}
+
 /*---------------------------------------
    PRICES
 -----------------------------------------*/


### PR DESCRIPTION
Fixes this
![image](https://user-images.githubusercontent.com/2544475/45243372-e3983400-b2f3-11e8-9801-80458134ba73.png)
to this
![image](https://user-images.githubusercontent.com/2544475/45243352-cebba080-b2f3-11e8-8342-f34a0b6c3723.png)
in the image section, for mobiles