### PR TITLE
Fixes for IE (Diacritics problem, calendar problem)

### DIFF
--- a/wp-content/themes/Parallax-One/customizer_defaults.php
+++ b/wp-content/themes/Parallax-One/customizer_defaults.php
@@ -327,6 +327,7 @@ class DefCalendar {
   public static $mode = 'condensed';
   public static $this_week = 'This week';
   public static $next_week = 'Next week';
+  public static $fallback = false;
 };
 
 /********************************************************/

--- a/wp-content/themes/Parallax-One/inc/customizer.php
+++ b/wp-content/themes/Parallax-One/inc/customizer.php
@@ -1744,6 +1744,20 @@ function parallax_one_customize_register( $wp_customize ) {
     'priority'    => 1
   ));
 
+  /* Calendar fallback */
+
+  $wp_customize->add_setting('parallax_one_calendar_fallback', array(
+      'default' => DefCalendar::$fallback,
+      'sanitize_callback' => 'parallax_one_sanitize_text'
+      ));
+  $wp_customize->add_control(
+      'parallax_one_calendar_fallback', array(
+      'type' => 'checkbox',
+      'label' => __('Use fallback image from Image section (if calendar cannot be loaded, e.g. on Internet Explorer)?', 'parallax-one'),
+      'section' => 'calendar_section',
+      'priority' => 4,
+  ));
+
   /* Calendar show/hide */
 
   $wp_customize->add_setting('parallax_one_calendar_show', array('sanitize_callback' => 'parallax_one_sanitize_text'));

--- a/wp-content/themes/Parallax-One/sections/parallax_one_calendar_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_calendar_section.php
@@ -7,7 +7,7 @@ $calendar_title = get_theme_mod('calendar_title', DefCalendar::$title);
 $calendar_mode = get_theme_mod('calendar_mode', DefCalendar::$mode);
 $calendar_this_week = get_theme_mod('calendar_this_week', DefCalendar::$this_week);
 $calendar_next_week = get_theme_mod('calendar_next_week', DefCalendar::$next_week);
-
+$calendar_fallback = get_theme_mod('calendar_fallback', DefCalendar::$fallback);
 ?>
 
 <script src="<?= get_bloginfo("template_url"); ?>/inc/calendar/frontend/app.js"></script>
@@ -60,8 +60,17 @@ $calendar_next_week = get_theme_mod('calendar_next_week', DefCalendar::$next_wee
               ng-show="calendar.weekIndex === weekIndex">
           </for-water-calendar>
           <div class="for-water-calendar-ie" style="display: none;">
-              Unfortunately, Internet Explorer / Edge cannot render the calendar properly. Please use Google Chrome or Mozilla Firefox to display the calendar.
-          </div>
+<?php
+                $static_image = get_theme_mod('image_section_static_image', parallax_get_file(DefImage::$static_image));
+                if ($static_image && $calendar_fallback) {
+                  echo '<div class="image-section-static-image"><img src="' . $static_image . '" /></div>';
+                } else {
+?>
+                    Unfortunately, Internet Explorer / Edge cannot render the calendar properly. Please use Google Chrome or Mozilla Firefox to display the calendar.
+<?php
+                }
+?>
+              </div>
           <div id="cal-switches">
             <calendar-week-switch></calendar-week-switch>
           </div>

--- a/wp-content/themes/Parallax-One/sections/parallax_one_calendar_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_calendar_section.php
@@ -7,7 +7,7 @@ $calendar_title = get_theme_mod('calendar_title', DefCalendar::$title);
 $calendar_mode = get_theme_mod('calendar_mode', DefCalendar::$mode);
 $calendar_this_week = get_theme_mod('calendar_this_week', DefCalendar::$this_week);
 $calendar_next_week = get_theme_mod('calendar_next_week', DefCalendar::$next_week);
-$calendar_fallback = get_theme_mod('calendar_fallback', DefCalendar::$fallback);
+$calendar_fallback = get_theme_mod('parallax_one_calendar_fallback', DefCalendar::$fallback);
 ?>
 
 <script src="<?= get_bloginfo("template_url"); ?>/inc/calendar/frontend/app.js"></script>
@@ -62,11 +62,11 @@ $calendar_fallback = get_theme_mod('calendar_fallback', DefCalendar::$fallback);
           <div class="for-water-calendar-ie" style="display: none;">
 <?php
                 $static_image = get_theme_mod('image_section_static_image', parallax_get_file(DefImage::$static_image));
-                if ($static_image && $calendar_fallback) {
+                if (isset($static_image) && (!empty($static_image)) && isset($calendar_fallback) && ($calendar_fallback == true)) {
                   echo '<div class="image-section-static-image"><img src="' . $static_image . '" /></div>';
                 } else {
 ?>
-                    Unfortunately, Internet Explorer / Edge cannot render the calendar properly. Please use Google Chrome or Mozilla Firefox to display the calendar.
+                    <div style="padding-bottom: 20px;">Unfortunately, Internet Explorer / Edge cannot render the calendar properly. Please use Google Chrome or Mozilla Firefox to display the calendar.</div>
 <?php
                 }
 ?>

--- a/wp-content/themes/Parallax-One/sections/parallax_one_calendar_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_calendar_section.php
@@ -59,6 +59,9 @@ $calendar_next_week = get_theme_mod('calendar_next_week', DefCalendar::$next_wee
               ng-repeat="calendar in calendars" 
               ng-show="calendar.weekIndex === weekIndex">
           </for-water-calendar>
+          <div class="for-water-calendar-ie" style="display: none;">
+              Unfortunately, Internet Explorer / Edge cannot render the calendar properly. Please use Google Chrome or Mozilla Firefox to display the calendar.
+          </div>
           <div id="cal-switches">
             <calendar-week-switch></calendar-week-switch>
           </div>

--- a/wp-content/themes/Parallax-One/style.css
+++ b/wp-content/themes/Parallax-One/style.css
@@ -1705,6 +1705,20 @@ section#calendar {
     padding-bottom: 20px;
 }
 
+div.for-water-calendar-ie {
+	display: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+	/* IE10+ CSS styles go here */
+	div.for-water-calendar {
+		display: none;
+	}
+	div.for-water-calendar-ie {
+		display: block;
+	}
+}
+
 /*---------------------------------------
    3.1 SECTION: HOME / HEADER         
 -----------------------------------------*/
@@ -5411,6 +5425,37 @@ em.policy-highlight {
 h2.policy {
 	font-size: 1.1em;
 	color: #008ed6;
+}
+
+/*---------------------------------------
+  3.19 FIXES FOR IE
+-----------------------------------------*/
+
+/* Unfortunately, font may get broken on IE if diacritics is in use, e.g. /prague/dance/cz
+A proper fix would be not using @import to import Avenir fonts, and using e.g. <link> in html.
+But as this fix was not tested and needs some trial&error, in the meantime the below hack is suggested.
+TODO: Implement a proper fix, or try to refactor how we use font-family: Avenir throughout this CSS
+- we have a lot of duplication there, and so the below fix has to be long
+*/
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {     /* IE10+ CSS styles go here */    body {
+	font-family: sans-serif !important;
+	font-weight: 100 !important;
+}
+	h1,h2,h3,h4,h5,h6 {
+		font-family: sans-serif !important;
+	}
+	.sub-heading {
+		font-family: sans-serif;
+		font-weight: 100 !important;
+	}
+	.intro-section h5 {
+		font-family: sans-serif !important;
+	}
+	#intro-under-construction {
+		font-family: sans-serif !important;
+		font-weight: 200 !important;
+	}
 }
 
 /*---------------------------------------

--- a/wp-content/themes/Parallax-One/style.css
+++ b/wp-content/themes/Parallax-One/style.css
@@ -5433,26 +5433,27 @@ h2.policy {
 
 /* Unfortunately, font may get broken on IE if diacritics is in use, e.g. /prague/dance/cz
 A proper fix would be not using @import to import Avenir fonts, and using e.g. <link> in html.
-But as this fix was not tested and needs some trial&error, in the meantime the below hack is suggested.
+But as this fix was not tested and needs some trial&error, in the meantime the below hack is suggested, that uses sans-serif as something that looks nice.
 TODO: Implement a proper fix, or try to refactor how we use font-family: Avenir throughout this CSS
 - we have a lot of duplication there, and so the below fix has to be long
 */
 
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {     /* IE10+ CSS styles go here */    body {
-	font-family: sans-serif !important;
-	font-weight: 100 !important;
-}
-	h1,h2,h3,h4,h5,h6 {
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {     /* IE10+ CSS styles go here */   
+	html:lang(cs-CS) body {
+		font-family: sans-serif !important;
+		font-weight: 100 !important;
+	}
+	html:lang(cs-CS) h1,h2,h3,h4,h5,h6 {
 		font-family: sans-serif !important;
 	}
-	.sub-heading {
+	html:lang(cs-CS) .sub-heading {
 		font-family: sans-serif;
 		font-weight: 100 !important;
 	}
-	.intro-section h5 {
+	html:lang(cs-CS) .intro-section h5 {
 		font-family: sans-serif !important;
 	}
-	#intro-under-construction {
+	html:lang(cs-CS) #intro-under-construction {
 		font-family: sans-serif !important;
 		font-weight: 200 !important;
 	}

--- a/wp-content/themes/Parallax-One/style.css
+++ b/wp-content/themes/Parallax-One/style.css
@@ -1712,10 +1712,10 @@ div.for-water-calendar-ie {
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
 	/* IE10+ CSS styles go here */
 	div.for-water-calendar {
-		display: none;
+		display: none !important;
 	}
 	div.for-water-calendar-ie {
-		display: block;
+		display: block !important;
 	}
 }
 
@@ -5434,26 +5434,14 @@ h2.policy {
 /* Unfortunately, font may get broken on IE if diacritics is in use, e.g. /prague/dance/cz
 A proper fix would be not using @import to import Avenir fonts, and using e.g. <link> in html.
 But as this fix was not tested and needs some trial&error, in the meantime the below hack is suggested, that uses sans-serif as something that looks nice.
-TODO: Implement a proper fix, or try to refactor how we use font-family: Avenir throughout this CSS
-- we have a lot of duplication there, and so the below fix has to be long
+TODO: Implement a proper fix using <link>, or try to refactor how we use font-family: Avenir throughout this CSS, so that this fix does not need to name so many elements
 */
 
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {     /* IE10+ CSS styles go here */   
-	html:lang(cs-CS) body {
-		font-family: sans-serif !important;
-		font-weight: 100 !important;
-	}
-	html:lang(cs-CS) h1,h2,h3,h4,h5,h6 {
+	html:lang(cs-CZ) h1,h2,h3,h4,h5,h6, html:lang(cs-CZ) body, html:lang(cs-CZ) p, html:lang(cs-CZ) div, html:lang(cs-CZ) span {
 		font-family: sans-serif !important;
 	}
-	html:lang(cs-CS) .sub-heading {
-		font-family: sans-serif;
-		font-weight: 100 !important;
-	}
-	html:lang(cs-CS) .intro-section h5 {
-		font-family: sans-serif !important;
-	}
-	html:lang(cs-CS) #intro-under-construction {
+	html:lang(cs-CZ) #intro-under-construction, html:lang(cs-CZ) #intro-under-construction span {
 		font-family: sans-serif !important;
 		font-weight: 200 !important;
 	}


### PR DESCRIPTION
Today I accidentally was trying Internet Explorer (11) and I realized Czech diacritics is broken, and what more, the calendar (i.e. Berlin site) looks very bad. Solution: fixing CSS (hacks for IE, I tried to use lang(cs-CZ) CSS selector, so we can specify the hacks only for affected sites), possibility to use Image instead of calendar, if IE 10+ is used.

Calendar on IE 11
![image](https://user-images.githubusercontent.com/2544475/45352628-35bdab80-b5b9-11e8-91b9-c6b0a8a587da.png)
(Prague page on IE 11, notice the ž, ě, Ř below)
![image](https://user-images.githubusercontent.com/2544475/45353371-f09a7900-b5ba-11e8-9360-282ded86f97d.png)
New switch in Calendar section in Customizer. If this is selected + image is present, IE 10+ will show the image instead,  if not, we write a message to use Google Chrome.
![image](https://user-images.githubusercontent.com/2544475/45350918-3a806080-b5b5-11e8-88ac-98077590576a.png)
example use of static image
![image](https://user-images.githubusercontent.com/2544475/45357157-ab2f7900-b5c5-11e8-91b4-29535a1ccec2.png)
if no static image
![image](https://user-images.githubusercontent.com/2544475/45355354-7cfb6a80-b5c0-11e8-89c0-c57da3f56370.png)
