### PR TITLE
Use nl2br in Why Us section

### DIFF
--- a/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
@@ -47,7 +47,7 @@
                   }
 
                   if(!empty($why_us_item->desc)) {
-                    echo '<p>'. nl2br(esc_attr($why_us_item->desc)).'</p>';
+                    echo '<p style="white-space: pre-line">'. esc_attr($why_us_item->desc).'</p>';
                   }
                   echo '</div>';
                   $counter++;

--- a/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
@@ -47,7 +47,7 @@
                   }
 
                   if(!empty($why_us_item->desc)) {
-                    echo '<p style="white-space: pre-line">'. esc_attr($why_us_item->desc).'</p>';
+                    echo '<p class="keep-newlines">'. esc_attr($why_us_item->desc).'</p>';
                   }
                   echo '</div>';
                   $counter++;

--- a/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
@@ -47,7 +47,7 @@
                   }
 
                   if(!empty($why_us_item->desc)) {
-                    echo '<p>'. nl2br($why_us_item->desc).'</p>';
+                    echo '<p>'. nl2br(esc_attr($why_us_item->desc)).'</p>';
                   }
                   echo '</div>';
                   $counter++;

--- a/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_why_us_section.php
@@ -47,7 +47,7 @@
                   }
 
                   if(!empty($why_us_item->desc)) {
-                    echo '<p>'. esc_attr($why_us_item->desc).'</p>';
+                    echo '<p>'. nl2br($why_us_item->desc).'</p>';
                   }
                   echo '</div>';
                   $counter++;

--- a/wp-content/themes/Parallax-One/style.css
+++ b/wp-content/themes/Parallax-One/style.css
@@ -1082,6 +1082,10 @@ img.why-us-img {
     height: 100px;
 }
 
+p.keep-newlines {
+	white-space: pre-line;
+}
+
 /* when why-us boxes are next to each other in wider viewport */
 
 @media (min-width: 992px) {


### PR DESCRIPTION
Just a small change allowing admins to use newline (enter) in Why Us section
![image](https://user-images.githubusercontent.com/2544475/75635369-c48f0f80-5c15-11ea-8b97-8c6e5e64396d.png)
