### PR TITLE
Contact Form update to 5.1.6

### DIFF
--- a/wp-content/plugins/contact-form-7/admin/admin.php
+++ b/wp-content/plugins/contact-form-7/admin/admin.php
@@ -4,60 +4,173 @@ require_once WPCF7_PLUGIN_DIR . '/admin/includes/admin-functions.php';
 require_once WPCF7_PLUGIN_DIR . '/admin/includes/help-tabs.php';
 require_once WPCF7_PLUGIN_DIR . '/admin/includes/tag-generator.php';
 require_once WPCF7_PLUGIN_DIR . '/admin/includes/welcome-panel.php';
+require_once WPCF7_PLUGIN_DIR . '/admin/includes/config-validator.php';
 
-add_action( 'admin_init', 'wpcf7_admin_init' );
+add_action( 'admin_init', 'wpcf7_admin_init', 10, 0 );
 
 function wpcf7_admin_init() {
 	do_action( 'wpcf7_admin_init' );
 }
 
-add_action( 'admin_menu', 'wpcf7_admin_menu', 9 );
+add_action( 'admin_menu', 'wpcf7_admin_menu', 9, 0 );
 
 function wpcf7_admin_menu() {
 	global $_wp_last_object_menu;
 
 	$_wp_last_object_menu++;
 
+	do_action( 'wpcf7_admin_menu' );
+
 	add_menu_page( __( 'Contact Form 7', 'contact-form-7' ),
-		__( 'Contact', 'contact-form-7' ),
+		__( 'Contact', 'contact-form-7' )
+			. wpcf7_admin_menu_change_notice(),
 		'wpcf7_read_contact_forms', 'wpcf7',
 		'wpcf7_admin_management_page', 'dashicons-email',
 		$_wp_last_object_menu );
 
 	$edit = add_submenu_page( 'wpcf7',
 		__( 'Edit Contact Form', 'contact-form-7' ),
-		__( 'Contact Forms', 'contact-form-7' ),
+		__( 'Contact Forms', 'contact-form-7' )
+			. wpcf7_admin_menu_change_notice( 'wpcf7' ),
 		'wpcf7_read_contact_forms', 'wpcf7',
 		'wpcf7_admin_management_page' );
 
-	add_action( 'load-' . $edit, 'wpcf7_load_contact_form_admin' );
+	add_action( 'load-' . $edit, 'wpcf7_load_contact_form_admin', 10, 0 );
 
 	$addnew = add_submenu_page( 'wpcf7',
 		__( 'Add New Contact Form', 'contact-form-7' ),
-		__( 'Add New', 'contact-form-7' ),
+		__( 'Add New', 'contact-form-7' )
+			. wpcf7_admin_menu_change_notice( 'wpcf7-new' ),
 		'wpcf7_edit_contact_forms', 'wpcf7-new',
 		'wpcf7_admin_add_new_page' );
 
-	add_action( 'load-' . $addnew, 'wpcf7_load_contact_form_admin' );
+	add_action( 'load-' . $addnew, 'wpcf7_load_contact_form_admin', 10, 0 );
 
 	$integration = WPCF7_Integration::get_instance();
 
 	if ( $integration->service_exists() ) {
 		$integration = add_submenu_page( 'wpcf7',
 			__( 'Integration with Other Services', 'contact-form-7' ),
-			__( 'Integration', 'contact-form-7' ),
+			__( 'Integration', 'contact-form-7' )
+				. wpcf7_admin_menu_change_notice( 'wpcf7-integration' ),
 			'wpcf7_manage_integration', 'wpcf7-integration',
 			'wpcf7_admin_integration_page' );
 
-		add_action( 'load-' . $integration, 'wpcf7_load_integration_page' );
+		add_action( 'load-' . $integration, 'wpcf7_load_integration_page', 10, 0 );
 	}
+}
+
+function wpcf7_admin_menu_change_notice( $menu_slug = '' ) {
+	$counts = apply_filters( 'wpcf7_admin_menu_change_notice',
+		array(
+			'wpcf7' => 0,
+			'wpcf7-new' => 0,
+			'wpcf7-integration' => 0,
+		)
+	);
+
+	if ( empty( $menu_slug ) ) {
+		$count = absint( array_sum( $counts ) );
+	} elseif ( isset( $counts[$menu_slug] ) ) {
+		$count = absint( $counts[$menu_slug] );
+	} else {
+		$count = 0;
+	}
+
+	if ( $count ) {
+		return sprintf(
+			' <span class="update-plugins %1$d"><span class="plugin-count">%2$s</span></span>',
+			$count,
+			esc_html( number_format_i18n( $count ) )
+		);
+	}
+
+	return '';
+}
+
+add_action( 'admin_enqueue_scripts', 'wpcf7_admin_enqueue_scripts', 10, 1 );
+
+function wpcf7_admin_enqueue_scripts( $hook_suffix ) {
+	if ( false === strpos( $hook_suffix, 'wpcf7' ) ) {
+		return;
+	}
+
+	wp_enqueue_style( 'contact-form-7-admin',
+		wpcf7_plugin_url( 'admin/css/styles.css' ),
+		array(), WPCF7_VERSION, 'all'
+	);
+
+	if ( wpcf7_is_rtl() ) {
+		wp_enqueue_style( 'contact-form-7-admin-rtl',
+			wpcf7_plugin_url( 'admin/css/styles-rtl.css' ),
+			array(), WPCF7_VERSION, 'all'
+		);
+	}
+
+	wp_enqueue_script( 'wpcf7-admin',
+		wpcf7_plugin_url( 'admin/js/scripts.js' ),
+		array( 'jquery', 'jquery-ui-tabs' ),
+		WPCF7_VERSION, true
+	);
+
+	$args = array(
+		'apiSettings' => array(
+			'root' => esc_url_raw( rest_url( 'contact-form-7/v1' ) ),
+			'namespace' => 'contact-form-7/v1',
+			'nonce' => ( wp_installing() && ! is_multisite() )
+				? '' : wp_create_nonce( 'wp_rest' ),
+		),
+		'pluginUrl' => wpcf7_plugin_url(),
+		'saveAlert' => __(
+			"The changes you made will be lost if you navigate away from this page.",
+			'contact-form-7' ),
+		'activeTab' => isset( $_GET['active-tab'] )
+			? (int) $_GET['active-tab'] : 0,
+		'configValidator' => array(
+			'errors' => array(),
+			'howToCorrect' => __( "How to resolve?", 'contact-form-7' ),
+			'oneError' => __( '1 configuration error detected', 'contact-form-7' ),
+			'manyErrors' => __( '%d configuration errors detected', 'contact-form-7' ),
+			'oneErrorInTab' => __( '1 configuration error detected in this tab panel', 'contact-form-7' ),
+			'manyErrorsInTab' => __( '%d configuration errors detected in this tab panel', 'contact-form-7' ),
+			'docUrl' => WPCF7_ConfigValidator::get_doc_link(),
+			/* translators: screen reader text */
+			'iconAlt' => __( '(configuration error)', 'contact-form-7' ),
+		),
+	);
+
+	if ( $post = wpcf7_get_current_contact_form()
+	and current_user_can( 'wpcf7_edit_contact_form', $post->id() )
+	and wpcf7_validate_configuration() ) {
+		$config_validator = new WPCF7_ConfigValidator( $post );
+		$config_validator->restore();
+		$args['configValidator']['errors'] =
+			$config_validator->collect_error_messages();
+	}
+
+	wp_localize_script( 'wpcf7-admin', 'wpcf7', $args );
+
+	add_thickbox();
+
+	wp_enqueue_script( 'wpcf7-admin-taggenerator',
+		wpcf7_plugin_url( 'admin/js/tag-generator.js' ),
+		array( 'jquery', 'thickbox', 'wpcf7-admin' ), WPCF7_VERSION, true );
+}
+
+add_action( 'doing_dark_mode', 'wpcf7_dark_mode_support', 10, 1 );
+
+function wpcf7_dark_mode_support( $user_id ) {
+	wp_enqueue_style( 'contact-form-7-admin-dark-mode',
+		wpcf7_plugin_url( 'admin/css/styles-dark-mode.css' ),
+		array( 'contact-form-7-admin' ), WPCF7_VERSION, 'screen' );
 }
 
 add_filter( 'set-screen-option', 'wpcf7_set_screen_options', 10, 3 );
 
 function wpcf7_set_screen_options( $result, $option, $value ) {
 	$wpcf7_screens = array(
-		'cfseven_contact_forms_per_page' );
+		'cfseven_contact_forms_per_page',
+	);
 
 	if ( in_array( $option, $wpcf7_screens ) ) {
 		$result = $value;
@@ -70,6 +183,11 @@ function wpcf7_load_contact_form_admin() {
 	global $plugin_page;
 
 	$action = wpcf7_current_action();
+
+	do_action( 'wpcf7_admin_load',
+		isset( $_GET['page'] ) ? trim( $_GET['page'] ) : '',
+		$action
+	);
 
 	if ( 'save' == $action ) {
 		$id = isset( $_POST['post_ID'] ) ? $_POST['post_ID'] : '-1';
@@ -92,12 +210,10 @@ function wpcf7_load_contact_form_admin() {
 			? $_POST['wpcf7-form'] : '';
 
 		$args['mail'] = isset( $_POST['wpcf7-mail'] )
-			? wpcf7_sanitize_mail( $_POST['wpcf7-mail'] )
-			: array();
+			? $_POST['wpcf7-mail'] : array();
 
 		$args['mail_2'] = isset( $_POST['wpcf7-mail-2'] )
-			? wpcf7_sanitize_mail( $_POST['wpcf7-mail-2'] )
-			: array();
+			? $_POST['wpcf7-mail-2'] : array();
 
 		$args['messages'] = isset( $_POST['wpcf7-messages'] )
 			? $_POST['wpcf7-messages'] : array();
@@ -107,7 +223,7 @@ function wpcf7_load_contact_form_admin() {
 
 		$contact_form = wpcf7_save_contact_form( $args );
 
-		if ( $contact_form && wpcf7_validate_configuration() ) {
+		if ( $contact_form and wpcf7_validate_configuration() ) {
 			$config_validator = new WPCF7_ConfigValidator( $contact_form );
 			$config_validator->validate();
 			$config_validator->save();
@@ -204,49 +320,6 @@ function wpcf7_load_contact_form_admin() {
 		exit();
 	}
 
-	if ( 'validate' == $action && wpcf7_validate_configuration() ) {
-		if ( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
-			check_admin_referer( 'wpcf7-bulk-validate' );
-
-			if ( ! current_user_can( 'wpcf7_edit_contact_forms' ) ) {
-				wp_die( __( "You are not allowed to validate configuration.", 'contact-form-7' ) );
-			}
-
-			$contact_forms = WPCF7_ContactForm::find();
-
-			$result = array(
-				'timestamp' => current_time( 'timestamp' ),
-				'version' => WPCF7_VERSION,
-				'count_valid' => 0,
-				'count_invalid' => 0,
-			);
-
-			foreach ( $contact_forms as $contact_form ) {
-				$config_validator = new WPCF7_ConfigValidator( $contact_form );
-				$config_validator->validate();
-				$config_validator->save();
-
-				if ( $config_validator->is_valid() ) {
-					$result['count_valid'] += 1;
-				} else {
-					$result['count_invalid'] += 1;
-				}
-			}
-
-			WPCF7::update_option( 'bulk_validate', $result );
-
-			$query = array(
-				'message' => 'validated',
-			);
-
-			$redirect_to = add_query_arg( $query, menu_page_url( 'wpcf7', false ) );
-			wp_safe_redirect( $redirect_to );
-			exit();
-		}
-	}
-
-	$_GET['post'] = isset( $_GET['post'] ) ? $_GET['post'] : '';
-
 	$post = null;
 
 	if ( 'wpcf7-new' == $plugin_page ) {
@@ -261,7 +334,8 @@ function wpcf7_load_contact_form_admin() {
 
 	$help_tabs = new WPCF7_Help_Tabs( $current_screen );
 
-	if ( $post && current_user_can( 'wpcf7_edit_contact_form', $post->id() ) ) {
+	if ( $post
+	and current_user_can( 'wpcf7_edit_contact_form', $post->id() ) ) {
 		$help_tabs->set_help_tabs( 'edit' );
 	} else {
 		$help_tabs->set_help_tabs( 'list' );
@@ -271,79 +345,13 @@ function wpcf7_load_contact_form_admin() {
 		}
 
 		add_filter( 'manage_' . $current_screen->id . '_columns',
-			array( 'WPCF7_Contact_Form_List_Table', 'define_columns' ) );
+			array( 'WPCF7_Contact_Form_List_Table', 'define_columns' ), 10, 0 );
 
 		add_screen_option( 'per_page', array(
 			'default' => 20,
 			'option' => 'cfseven_contact_forms_per_page',
 		) );
 	}
-}
-
-add_action( 'admin_enqueue_scripts', 'wpcf7_admin_enqueue_scripts' );
-
-function wpcf7_admin_enqueue_scripts( $hook_suffix ) {
-	if ( false === strpos( $hook_suffix, 'wpcf7' ) ) {
-		return;
-	}
-
-	wp_enqueue_style( 'contact-form-7-admin',
-		wpcf7_plugin_url( 'admin/css/styles.css' ),
-		array(), WPCF7_VERSION, 'all' );
-
-	if ( wpcf7_is_rtl() ) {
-		wp_enqueue_style( 'contact-form-7-admin-rtl',
-			wpcf7_plugin_url( 'admin/css/styles-rtl.css' ),
-			array(), WPCF7_VERSION, 'all' );
-	}
-
-	wp_enqueue_script( 'wpcf7-admin',
-		wpcf7_plugin_url( 'admin/js/scripts.js' ),
-		array( 'jquery', 'jquery-ui-tabs' ),
-		WPCF7_VERSION, true );
-
-	$args = array(
-		'apiSettings' => array(
-			'root' => esc_url_raw( rest_url( 'contact-form-7/v1' ) ),
-			'namespace' => 'contact-form-7/v1',
-			'nonce' => ( wp_installing() && ! is_multisite() )
-				? '' : wp_create_nonce( 'wp_rest' ),
-		),
-		'pluginUrl' => wpcf7_plugin_url(),
-		'saveAlert' => __(
-			"The changes you made will be lost if you navigate away from this page.",
-			'contact-form-7' ),
-		'activeTab' => isset( $_GET['active-tab'] )
-			? (int) $_GET['active-tab'] : 0,
-		'configValidator' => array(
-			'errors' => array(),
-			'howToCorrect' => __( "How to resolve?", 'contact-form-7' ),
-			'oneError' => __( '1 configuration error detected', 'contact-form-7' ),
-			'manyErrors' => __( '%d configuration errors detected', 'contact-form-7' ),
-			'oneErrorInTab' => __( '1 configuration error detected in this tab panel', 'contact-form-7' ),
-			'manyErrorsInTab' => __( '%d configuration errors detected in this tab panel', 'contact-form-7' ),
-			'docUrl' => WPCF7_ConfigValidator::get_doc_link(),
-			/* translators: screen reader text */
-			'iconAlt' => __( '(configuration error)', 'contact-form-7' ),
-		),
-	);
-
-	if ( ( $post = wpcf7_get_current_contact_form() )
-	&& current_user_can( 'wpcf7_edit_contact_form', $post->id() )
-	&& wpcf7_validate_configuration() ) {
-		$config_validator = new WPCF7_ConfigValidator( $post );
-		$config_validator->restore();
-		$args['configValidator']['errors'] =
-			$config_validator->collect_error_messages();
-	}
-
-	wp_localize_script( 'wpcf7-admin', 'wpcf7', $args );
-
-	add_thickbox();
-
-	wp_enqueue_script( 'wpcf7-admin-taggenerator',
-		wpcf7_plugin_url( 'admin/js/tag-generator.js' ),
-		array( 'jquery', 'thickbox', 'wpcf7-admin' ), WPCF7_VERSION, true );
 }
 
 function wpcf7_admin_management_page() {
@@ -356,8 +364,8 @@ function wpcf7_admin_management_page() {
 	}
 
 	if ( 'validate' == wpcf7_current_action()
-	&& wpcf7_validate_configuration()
-	&& current_user_can( 'wpcf7_edit_contact_forms' ) ) {
+	and wpcf7_validate_configuration()
+	and current_user_can( 'wpcf7_edit_contact_forms' ) ) {
 		wpcf7_admin_bulk_validate_page();
 		return;
 	}
@@ -366,7 +374,7 @@ function wpcf7_admin_management_page() {
 	$list_table->prepare_items();
 
 ?>
-<div class="wrap">
+<div class="wrap" id="wpcf7-contact-form-list-table">
 
 <h1 class="wp-heading-inline"><?php
 	echo esc_html( __( 'Contact Forms', 'contact-form-7' ) );
@@ -374,59 +382,39 @@ function wpcf7_admin_management_page() {
 
 <?php
 	if ( current_user_can( 'wpcf7_edit_contact_forms' ) ) {
-		echo sprintf( '<a href="%1$s" class="add-new-h2">%2$s</a>',
-			esc_url( menu_page_url( 'wpcf7-new', false ) ),
-			esc_html( __( 'Add New', 'contact-form-7' ) ) );
+		echo wpcf7_link(
+			menu_page_url( 'wpcf7-new', false ),
+			__( 'Add New', 'contact-form-7' ),
+			array( 'class' => 'page-title-action' )
+		);
 	}
 
 	if ( ! empty( $_REQUEST['s'] ) ) {
 		echo sprintf( '<span class="subtitle">'
 			/* translators: %s: search keywords */
 			. __( 'Search results for &#8220;%s&#8221;', 'contact-form-7' )
-			. '</span>', esc_html( $_REQUEST['s'] ) );
+			. '</span>', esc_html( $_REQUEST['s'] )
+		);
 	}
 ?>
 
 <hr class="wp-header-end">
 
-<?php do_action( 'wpcf7_admin_warnings' ); ?>
-<?php wpcf7_welcome_panel(); ?>
-<?php do_action( 'wpcf7_admin_notices' ); ?>
+<?php
+	do_action( 'wpcf7_admin_warnings',
+		'wpcf7', wpcf7_current_action(), null );
+
+	wpcf7_welcome_panel();
+
+	do_action( 'wpcf7_admin_notices',
+		'wpcf7', wpcf7_current_action(), null );
+?>
 
 <form method="get" action="">
 	<input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>" />
 	<?php $list_table->search_box( __( 'Search Contact Forms', 'contact-form-7' ), 'wpcf7-contact' ); ?>
 	<?php $list_table->display(); ?>
 </form>
-
-</div>
-<?php
-}
-
-function wpcf7_admin_bulk_validate_page() {
-	$contact_forms = WPCF7_ContactForm::find();
-	$count = WPCF7_ContactForm::count();
-
-	$submit_text = sprintf(
-		/* translators: %s: number of contact forms */
-		_n(
-			"Validate %s Contact Form Now",
-			"Validate %s Contact Forms Now",
-			$count, 'contact-form-7' ),
-		number_format_i18n( $count ) );
-
-?>
-<div class="wrap">
-
-<h1><?php echo esc_html( __( 'Validate Configuration', 'contact-form-7' ) ); ?></h1>
-
-<form method="post" action="">
-	<input type="hidden" name="action" value="validate" />
-	<?php wp_nonce_field( 'wpcf7-bulk-validate' ); ?>
-	<p><input type="submit" class="button" value="<?php echo esc_attr( $submit_text ); ?>" /></p>
-</form>
-
-<?php echo wpcf7_link( __( 'https://contactform7.com/configuration-validator-faq/', 'contact-form-7' ), __( 'FAQ about Configuration Validator', 'contact-form-7' ) ); ?>
 
 </div>
 <?php
@@ -446,10 +434,15 @@ function wpcf7_admin_add_new_page() {
 }
 
 function wpcf7_load_integration_page() {
+	do_action( 'wpcf7_admin_load',
+		isset( $_GET['page'] ) ? trim( $_GET['page'] ) : '',
+		wpcf7_current_action()
+	);
+
 	$integration = WPCF7_Integration::get_instance();
 
 	if ( isset( $_REQUEST['service'] )
-	&& $integration->service_exists( $_REQUEST['service'] ) ) {
+	and $integration->service_exists( $_REQUEST['service'] ) ) {
 		$service = $integration->get_service( $_REQUEST['service'] );
 		$service->load( wpcf7_current_action() );
 	}
@@ -461,17 +454,23 @@ function wpcf7_load_integration_page() {
 function wpcf7_admin_integration_page() {
 	$integration = WPCF7_Integration::get_instance();
 
+	$service = isset( $_REQUEST['service'] )
+		? $integration->get_service( $_REQUEST['service'] )
+		: null;
+
 ?>
-<div class="wrap">
+<div class="wrap" id="wpcf7-integration">
 
 <h1><?php echo esc_html( __( 'Integration with Other Services', 'contact-form-7' ) ); ?></h1>
 
-<?php do_action( 'wpcf7_admin_warnings' ); ?>
-<?php do_action( 'wpcf7_admin_notices' ); ?>
-
 <?php
-	if ( isset( $_REQUEST['service'] )
-	&& $service = $integration->get_service( $_REQUEST['service'] ) ) {
+	do_action( 'wpcf7_admin_warnings',
+		'wpcf7-integration', wpcf7_current_action(), $service );
+
+	do_action( 'wpcf7_admin_notices',
+		'wpcf7-integration', wpcf7_current_action(), $service );
+
+	if ( $service ) {
 		$message = isset( $_REQUEST['message'] ) ? $_REQUEST['message'] : '';
 		$service->admin_notice( $message );
 		$integration->list_services( array( 'include' => $_REQUEST['service'] ) );
@@ -486,9 +485,13 @@ function wpcf7_admin_integration_page() {
 
 /* Misc */
 
-add_action( 'wpcf7_admin_notices', 'wpcf7_admin_updated_message' );
+add_action( 'wpcf7_admin_notices', 'wpcf7_admin_updated_message', 10, 3 );
 
-function wpcf7_admin_updated_message() {
+function wpcf7_admin_updated_message( $page, $action, $object ) {
+	if ( ! in_array( $page, array( 'wpcf7', 'wpcf7-new' ) ) ) {
+		return;
+	}
+
 	if ( empty( $_REQUEST['message'] ) ) {
 		return;
 	}
@@ -521,12 +524,14 @@ function wpcf7_admin_updated_message() {
 
 		if ( $count_invalid ) {
 			$updated_message = sprintf(
-				/* translators: %s: number of contact forms */
 				_n(
+					/* translators: %s: number of contact forms */
 					"Configuration validation completed. %s invalid contact form was found.",
 					"Configuration validation completed. %s invalid contact forms were found.",
-					$count_invalid, 'contact-form-7' ),
-				number_format_i18n( $count_invalid ) );
+					$count_invalid, 'contact-form-7'
+				),
+				number_format_i18n( $count_invalid )
+			);
 
 			echo sprintf( '<div id="message" class="notice notice-warning is-dismissible"><p>%s</p></div>', esc_html( $updated_message ) );
 		} else {
@@ -550,18 +555,19 @@ function wpcf7_plugin_action_links( $links, $file ) {
 		return $links;
 	}
 
-	$settings_link = sprintf( '<a href="%1$s">%2$s</a>',
+	$settings_link = wpcf7_link(
 		menu_page_url( 'wpcf7', false ),
-		esc_html( __( 'Settings', 'contact-form-7' ) ) );
+		__( 'Settings', 'contact-form-7' )
+	);
 
 	array_unshift( $links, $settings_link );
 
 	return $links;
 }
 
-add_action( 'wpcf7_admin_warnings', 'wpcf7_old_wp_version_error' );
+add_action( 'wpcf7_admin_warnings', 'wpcf7_old_wp_version_error', 10, 3 );
 
-function wpcf7_old_wp_version_error() {
+function wpcf7_old_wp_version_error( $page, $action, $object ) {
 	$wp_version = get_bloginfo( 'version' );
 
 	if ( ! version_compare( $wp_version, WPCF7_REQUIRED_WP_VERSION, '<' ) ) {
@@ -571,23 +577,28 @@ function wpcf7_old_wp_version_error() {
 ?>
 <div class="notice notice-warning">
 <p><?php
-	/* translators: 1: version of Contact Form 7, 2: version of WordPress, 3: URL */
-	echo sprintf( __( '<strong>Contact Form 7 %1$s requires WordPress %2$s or higher.</strong> Please <a href="%3$s">update WordPress</a> first.', 'contact-form-7' ), WPCF7_VERSION, WPCF7_REQUIRED_WP_VERSION, admin_url( 'update-core.php' ) );
+	echo sprintf(
+		/* translators: 1: version of Contact Form 7, 2: version of WordPress, 3: URL */
+		__( '<strong>Contact Form 7 %1$s requires WordPress %2$s or higher.</strong> Please <a href="%3$s">update WordPress</a> first.', 'contact-form-7' ),
+		WPCF7_VERSION,
+		WPCF7_REQUIRED_WP_VERSION,
+		admin_url( 'update-core.php' )
+	);
 ?></p>
 </div>
 <?php
 }
 
-add_action( 'wpcf7_admin_warnings', 'wpcf7_not_allowed_to_edit' );
+add_action( 'wpcf7_admin_warnings', 'wpcf7_not_allowed_to_edit', 10, 3 );
 
-function wpcf7_not_allowed_to_edit() {
-	if ( ! $contact_form = wpcf7_get_current_contact_form() ) {
+function wpcf7_not_allowed_to_edit( $page, $action, $object ) {
+	if ( $object instanceof WPCF7_ContactForm ) {
+		$contact_form = $object;
+	} else {
 		return;
 	}
 
-	$post_id = $contact_form->id();
-
-	if ( current_user_can( 'wpcf7_edit_contact_form', $post_id ) ) {
+	if ( current_user_can( 'wpcf7_edit_contact_form', $contact_form->id() ) ) {
 		return;
 	}
 
@@ -597,37 +608,4 @@ function wpcf7_not_allowed_to_edit() {
 	echo sprintf(
 		'<div class="notice notice-warning"><p>%s</p></div>',
 		esc_html( $message ) );
-}
-
-add_action( 'wpcf7_admin_warnings', 'wpcf7_notice_bulk_validate_config', 5 );
-
-function wpcf7_notice_bulk_validate_config() {
-	if ( ! wpcf7_validate_configuration()
-	|| ! current_user_can( 'wpcf7_edit_contact_forms' ) ) {
-		return;
-	}
-
-	if ( isset( $_GET['page'] ) && 'wpcf7' == $_GET['page']
-	&& isset( $_GET['action'] ) && 'validate' == $_GET['action'] ) {
-		return;
-	}
-
-	$result = WPCF7::get_option( 'bulk_validate' );
-	$last_important_update = '4.9';
-
-	if ( ! empty( $result['version'] )
-	&& version_compare( $last_important_update, $result['version'], '<=' ) ) {
-		return;
-	}
-
-	$link = add_query_arg(
-		array( 'action' => 'validate' ),
-		menu_page_url( 'wpcf7', false ) );
-
-	$link = sprintf( '<a href="%s">%s</a>', $link, esc_html( __( 'Validate Contact Form 7 Configuration', 'contact-form-7' ) ) );
-
-	$message = __( "Misconfiguration leads to mail delivery failure or other troubles. Validate your contact forms now.", 'contact-form-7' );
-
-	echo sprintf( '<div class="notice notice-warning"><p>%s &raquo; %s</p></div>',
-		esc_html( $message ), $link );
 }

--- a/wp-content/plugins/contact-form-7/admin/css/styles-dark-mode.css
+++ b/wp-content/plugins/contact-form-7/admin/css/styles-dark-mode.css
@@ -1,0 +1,72 @@
+#wpcf7-contact-form-list-table span.shortcode input,
+#wpcf7-contact-form-editor span.shortcode input {
+	color: #fff;
+}
+
+div.config-error, span.config-error, ul.config-error {
+	color: #bbc8d4;
+}
+
+.keyboard-interaction {
+	color: #bbc8d4;
+}
+
+#contact-form-editor .contact-form-editor-panel {
+	background-color: #32373c;
+}
+
+#contact-form-editor-tabs {
+	border-bottom: 1px solid #aaa;
+}
+
+#contact-form-editor-tabs li {
+	border: 1px solid #ccc;
+	border-bottom: 1px solid #aaa;
+	background-color: #37444c;
+}
+
+#contact-form-editor-tabs li:hover {
+	background-color: #000;
+}
+
+#contact-form-editor-tabs li.ui-tabs-active,
+#contact-form-editor-tabs li.ui-tabs-active:hover {
+	border-top: 1px solid #aaa;
+	border-right: 1px solid #aaa;
+	border-left: 1px solid #aaa;
+	border-bottom: 1px solid #32373c;
+	background-color: #32373c;
+}
+
+#contact-form-editor-tabs li a {
+	color: #bbc8d4;
+}
+
+#contact-form-editor-tabs li.ui-tabs-active a {
+	color: #fff;
+}
+
+#contact-form-editor-tabs li a:hover {
+	color: #fff;
+}
+
+.contact-form-editor-box-mail span.mailtag {
+	color: #ddd;
+}
+
+.contact-form-editor-box-mail span.mailtag.used {
+	color: #999;
+}
+
+#mail-panel .contact-form-editor-box-mail table.form-table tr th,
+#mail-panel .contact-form-editor-box-mail table.form-table tr td {
+	background-color: #32373c;
+}
+
+div.wrap#wpcf7-integration .card.active {
+	border-color: #00a0d2;
+}
+
+div.wrap#wpcf7-integration .card .infobox {
+	color: #aaa;
+}

--- a/wp-content/plugins/contact-form-7/admin/css/styles-rtl.css
+++ b/wp-content/plugins/contact-form-7/admin/css/styles-rtl.css
@@ -5,10 +5,6 @@
 	padding: 9px 10px 0 15px;
 }
 
-#contact-form-editor-tabs li a span.dashicons {
-	padding: 6px 4px 4px 0;
-}
-
 /*
  * Form Tab
  */

--- a/wp-content/plugins/contact-form-7/admin/css/styles.css
+++ b/wp-content/plugins/contact-form-7/admin/css/styles.css
@@ -16,14 +16,25 @@ span.shortcode.old {
 	color: #fff;
 }
 
-span.shortcode > input {
-	background: inherit;
-	color: inherit;
+span.shortcode input {
 	font-size: 12px;
 	border: none;
 	box-shadow: none;
 	padding: 4px 8px;
 	margin: 0;
+}
+
+#wpcf7-contact-form-list-table span.shortcode input,
+#wpcf7-contact-form-editor span.shortcode input {
+	background: transparent;
+}
+
+#wpcf7-contact-form-list-table span.shortcode input {
+	color: #444;
+}
+
+#wpcf7-contact-form-editor span.shortcode input {
+	color: #fff;
 }
 
 #submitpost input.copy {
@@ -72,13 +83,28 @@ ul.config-error li {
 	margin: 0;
 }
 
-div.config-error span.dashicons,
-ul.config-error li span.dashicons {
-	color: #82878c;
-}
-
 [data-config-field][aria-invalid="true"] {
 	border-color: #d00;
+}
+
+#contact-form-editor-tabs li a .icon-in-circle,
+#contact-form-editor .config-error .icon-in-circle,
+.wp-list-table .config-error .icon-in-circle,
+.icon-in-circle {
+	display: inline-block;
+	vertical-align: text-top;
+	margin: 1px 6px 0;
+	padding: 0 5px;
+	min-width: 7px;
+	height: 17px;
+	border-radius: 11px;
+	background-color: #ca4a1f;
+	color: #fff;
+	font-size: 12px;
+	font-weight: bold;
+	line-height: 17px;
+	text-align: center;
+	z-index: 26;
 }
 
 /*
@@ -132,22 +158,11 @@ ul.config-error li span.dashicons {
 	color: #000;
 }
 
-#contact-form-editor-tabs li a span.dashicons {
-	font-style: normal;
-	padding: 6px 0 4px 4px;
-	color: #82878c;
-}
-
-#contact-form-editor-tabs li a span.dashicons-warning,
-#contact-form-editor .contact-form-editor-panel > div.config-error span.dashicons-warning {
-	color: #ca4a1f;
-}
-
 #contact-form-editor .contact-form-editor-panel > div.config-error {
 	margin-bottom: 1.4em;
 }
 
-#contact-form-editor-tabs li.ui-tabs-active a span.dashicons {
+#contact-form-editor-tabs li.ui-tabs-active a .icon-in-circle {
 	display: none;
 }
 
@@ -327,10 +342,6 @@ ul.config-error li span.dashicons {
 	width: 38%;
 }
 
-.wp-list-table .config-error span.dashicons-warning {
-	color: #ca4a1f;
-}
-
 /*
  * Welcome Panel
  */
@@ -421,4 +432,8 @@ ul.config-error li span.dashicons {
 
 .card .inside .form-table td {
 	padding: 10px 10px;
+}
+
+.card .checkboxes li {
+	margin: 0;
 }

--- a/wp-content/plugins/contact-form-7/admin/edit-contact-form.php
+++ b/wp-content/plugins/contact-form-7/admin/edit-contact-form.php
@@ -29,7 +29,7 @@ function wpcf7_admin_save_button( $post_id ) {
 	echo $button;
 }
 
-?><div class="wrap">
+?><div class="wrap" id="wpcf7-contact-form-editor">
 
 <h1 class="wp-heading-inline"><?php
 	if ( $post->initial() ) {
@@ -40,17 +40,31 @@ function wpcf7_admin_save_button( $post_id ) {
 ?></h1>
 
 <?php
-	if ( ! $post->initial() && current_user_can( 'wpcf7_edit_contact_forms' ) ) {
-		echo sprintf( '<a href="%1$s" class="add-new-h2">%2$s</a>',
-			esc_url( menu_page_url( 'wpcf7-new', false ) ),
-			esc_html( __( 'Add New', 'contact-form-7' ) ) );
+	if ( ! $post->initial()
+	and current_user_can( 'wpcf7_edit_contact_forms' ) ) {
+		echo wpcf7_link(
+			menu_page_url( 'wpcf7-new', false ),
+			__( 'Add New', 'contact-form-7' ),
+			array( 'class' => 'page-title-action' )
+		);
 	}
 ?>
 
 <hr class="wp-header-end">
 
-<?php do_action( 'wpcf7_admin_warnings' ); ?>
-<?php do_action( 'wpcf7_admin_notices' ); ?>
+<?php
+	do_action( 'wpcf7_admin_warnings',
+		$post->initial() ? 'wpcf7-new' : 'wpcf7',
+		wpcf7_current_action(),
+		$post
+	);
+
+	do_action( 'wpcf7_admin_notices',
+		$post->initial() ? 'wpcf7-new' : 'wpcf7',
+		wpcf7_current_action(),
+		$post
+	);
+?>
 
 <?php
 if ( $post ) :
@@ -187,23 +201,10 @@ if ( $post ) :
 			__( 'https://wordpress.org/support/plugin/contact-form-7/', 'contact-form-7' ),
 			__( 'Support Forums', 'contact-form-7' )
 		); ?></li>
-<?php
-	$pro_service_langs = array(
-		'en',	// English
-		'de',	// German
-		'fr',	// French
-		'es',	// Spanish
-	);
-
-	if ( in_array( substr( get_user_locale(), 0, 2 ), $pro_service_langs ) ) :
-?>
 		<li><?php echo wpcf7_link(
 			__( 'https://contactform7.com/custom-development/', 'contact-form-7' ),
 			__( 'Professional Services', 'contact-form-7' )
 		); ?></li>
-<?php
-	endif;
-?>
 	</ol>
 </div>
 </div><!-- #informationdiv -->
@@ -253,8 +254,8 @@ if ( $post ) :
 
 		$panels['additional-settings-panel'] = array(
 			'title' => $additional_settings
-				/* translators: %d: number of additional settings */
 				? sprintf(
+					/* translators: %d: number of additional settings */
 					__( 'Additional Settings (%d)', 'contact-form-7' ),
 					$additional_settings )
 				: __( 'Additional Settings', 'contact-form-7' ),

--- a/wp-content/plugins/contact-form-7/admin/includes/admin-functions.php
+++ b/wp-content/plugins/contact-form-7/admin/includes/admin-functions.php
@@ -1,11 +1,11 @@
 <?php
 
 function wpcf7_current_action() {
-	if ( isset( $_REQUEST['action'] ) && -1 != $_REQUEST['action'] ) {
+	if ( isset( $_REQUEST['action'] ) and -1 != $_REQUEST['action'] ) {
 		return $_REQUEST['action'];
 	}
 
-	if ( isset( $_REQUEST['action2'] ) && -1 != $_REQUEST['action2'] ) {
+	if ( isset( $_REQUEST['action2'] ) and -1 != $_REQUEST['action2'] ) {
 		return $_REQUEST['action2'];
 	}
 

--- a/wp-content/plugins/contact-form-7/admin/includes/class-contact-forms-list-table.php
+++ b/wp-content/plugins/contact-form-7/admin/includes/class-contact-forms-list-table.php
@@ -18,7 +18,7 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 		return $columns;
 	}
 
-	function __construct() {
+	public function __construct() {
 		parent::__construct( array(
 			'singular' => 'post',
 			'plural' => 'posts',
@@ -26,11 +26,9 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 		) );
 	}
 
-	function prepare_items() {
+	public function prepare_items() {
 		$current_screen = get_current_screen();
 		$per_page = $this->get_items_per_page( 'cfseven_contact_forms_per_page' );
-
-		$this->_column_headers = $this->get_column_info();
 
 		$args = array(
 			'posts_per_page' => $per_page,
@@ -73,11 +71,11 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 		) );
 	}
 
-	function get_columns() {
+	public function get_columns() {
 		return get_column_headers( get_current_screen() );
 	}
 
-	function get_sortable_columns() {
+	protected function get_sortable_columns() {
 		$columns = array(
 			'title' => array( 'title', true ),
 			'author' => array( 'author', false ),
@@ -87,7 +85,7 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 		return $columns;
 	}
 
-	function get_bulk_actions() {
+	protected function get_bulk_actions() {
 		$actions = array(
 			'delete' => __( 'Delete', 'contact-form-7' ),
 		);
@@ -95,75 +93,105 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 		return $actions;
 	}
 
-	function column_default( $item, $column_name ) {
+	protected function column_default( $item, $column_name ) {
 		return '';
 	}
 
-	function column_cb( $item ) {
+	public function column_cb( $item ) {
 		return sprintf(
 			'<input type="checkbox" name="%1$s[]" value="%2$s" />',
 			$this->_args['singular'],
-			$item->id() );
+			$item->id()
+		);
 	}
 
-	function column_title( $item ) {
-		$url = admin_url( 'admin.php?page=wpcf7&post=' . absint( $item->id() ) );
-		$edit_link = add_query_arg( array( 'action' => 'edit' ), $url );
+	public function column_title( $item ) {
+		$edit_link = add_query_arg(
+			array(
+				'post' => absint( $item->id() ),
+				'action' => 'edit',
+			),
+			menu_page_url( 'wpcf7', false )
+		);
 
 		$output = sprintf(
-			'<a class="row-title" href="%1$s" title="%2$s">%3$s</a>',
+			'<a class="row-title" href="%1$s" aria-label="%2$s">%3$s</a>',
 			esc_url( $edit_link ),
-			/* translators: %s: title of contact form */
-			esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;', 'contact-form-7' ),
-				$item->title() ) ),
+			esc_attr( sprintf(
+				/* translators: %s: title of contact form */
+				__( 'Edit &#8220;%s&#8221;', 'contact-form-7' ),
+				$item->title()
+			) ),
 			esc_html( $item->title() )
 		);
 
 		$output = sprintf( '<strong>%s</strong>', $output );
 
 		if ( wpcf7_validate_configuration()
-		&& current_user_can( 'wpcf7_edit_contact_form', $item->id() ) ) {
+		and current_user_can( 'wpcf7_edit_contact_form', $item->id() ) ) {
 			$config_validator = new WPCF7_ConfigValidator( $item );
 			$config_validator->restore();
 
 			if ( $count_errors = $config_validator->count_errors() ) {
 				$error_notice = sprintf(
-					/* translators: %s: number of errors detected */
 					_n(
+						/* translators: %s: number of errors detected */
 						'%s configuration error detected',
 						'%s configuration errors detected',
 						$count_errors, 'contact-form-7' ),
-					number_format_i18n( $count_errors ) );
+					number_format_i18n( $count_errors )
+				);
+
 				$output .= sprintf(
-					'<div class="config-error"><span class="dashicons dashicons-warning" aria-hidden="true"></span> %s</div>',
-					$error_notice );
+					'<div class="config-error"><span class="icon-in-circle" aria-hidden="true">!</span> %s</div>',
+					$error_notice
+				);
 			}
 		}
-
-		$actions = array(
-			'edit' => sprintf( '<a href="%1$s">%2$s</a>',
-				esc_url( $edit_link ),
-				esc_html( __( 'Edit', 'contact-form-7' ) ) ) );
-
-		if ( current_user_can( 'wpcf7_edit_contact_form', $item->id() ) ) {
-			$copy_link = wp_nonce_url(
-				add_query_arg( array( 'action' => 'copy' ), $url ),
-				'wpcf7-copy-contact-form_' . absint( $item->id() ) );
-
-			$actions = array_merge( $actions, array(
-				'copy' => sprintf( '<a href="%1$s">%2$s</a>',
-					esc_url( $copy_link ),
-					esc_html( __( 'Duplicate', 'contact-form-7' ) )
-				),
-			) );
-		}
-
-		$output .= $this->row_actions( $actions );
 
 		return $output;
 	}
 
-	function column_author( $item ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
+		if ( $column_name !== $primary ) {
+			return '';
+		}
+
+		$edit_link = add_query_arg(
+			array(
+				'post' => absint( $item->id() ),
+				'action' => 'edit',
+			),
+			menu_page_url( 'wpcf7', false )
+		);
+
+		$actions = array(
+			'edit' => wpcf7_link( $edit_link, __( 'Edit', 'contact-form-7' ) ),
+		);
+
+		if ( current_user_can( 'wpcf7_edit_contact_form', $item->id() ) ) {
+			$copy_link = add_query_arg(
+				array(
+					'post' => absint( $item->id() ),
+					'action' => 'copy',
+				),
+				menu_page_url( 'wpcf7', false )
+			);
+
+			$copy_link = wp_nonce_url(
+				$copy_link,
+				'wpcf7-copy-contact-form_' . absint( $item->id() )
+			);
+
+			$actions = array_merge( $actions, array(
+				'copy' => wpcf7_link( $copy_link, __( 'Duplicate', 'contact-form-7' ) ),
+			) );
+		}
+
+		return $this->row_actions( $actions );
+	}
+
+	public function column_author( $item ) {
 		$post = get_post( $item->id() );
 
 		if ( ! $post ) {
@@ -179,7 +207,7 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 		return esc_html( $author->display_name );
 	}
 
-	function column_shortcode( $item ) {
+	public function column_shortcode( $item ) {
 		$shortcodes = array( $item->shortcode() );
 
 		$output = '';
@@ -194,7 +222,7 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 		return trim( $output );
 	}
 
-	function column_date( $item ) {
+	public function column_date( $item ) {
 		$post = get_post( $item->id() );
 
 		if ( ! $post ) {
@@ -209,14 +237,19 @@ class WPCF7_Contact_Form_List_Table extends WP_List_Table {
 
 		$time_diff = time() - $time;
 
-		if ( $time_diff > 0 && $time_diff < 24*60*60 ) {
-			/* translators: %s: time since the creation of the contact form */
+		if ( $time_diff > 0 and $time_diff < 24*60*60 ) {
 			$h_time = sprintf(
-				__( '%s ago', 'contact-form-7' ), human_time_diff( $time ) );
+				/* translators: %s: time since the creation of the contact form */
+				__( '%s ago', 'contact-form-7' ),
+				human_time_diff( $time )
+			);
 		} else {
 			$h_time = mysql2date( __( 'Y/m/d', 'contact-form-7' ), $m_time );
 		}
 
-		return '<abbr title="' . $t_time . '">' . $h_time . '</abbr>';
+		return sprintf( '<abbr title="%2$s">%1$s</abbr>',
+			esc_html( $h_time ),
+			esc_attr( $t_time )
+		);
 	}
 }

--- a/wp-content/plugins/contact-form-7/admin/includes/config-validator.php
+++ b/wp-content/plugins/contact-form-7/admin/includes/config-validator.php
@@ -1,0 +1,137 @@
+<?php
+
+add_action( 'wpcf7_admin_menu', 'wpcf7_admin_init_bulk_cv', 10, 0 );
+
+function wpcf7_admin_init_bulk_cv() {
+	if ( ! wpcf7_validate_configuration()
+	or ! current_user_can( 'wpcf7_edit_contact_forms' ) ) {
+		return;
+	}
+
+	$result = WPCF7::get_option( 'bulk_validate' );
+	$last_important_update = '5.1.5';
+
+	if ( ! empty( $result['version'] )
+	and version_compare( $last_important_update, $result['version'], '<=' ) ) {
+		return;
+	}
+
+	add_filter( 'wpcf7_admin_menu_change_notice',
+		'wpcf7_admin_menu_change_notice_bulk_cv', 10, 1 );
+
+	add_action( 'wpcf7_admin_warnings',
+		'wpcf7_admin_warnings_bulk_cv', 5, 3 );
+}
+
+function wpcf7_admin_menu_change_notice_bulk_cv( $counts ) {
+	$counts['wpcf7'] += 1;
+	return $counts;
+}
+
+function wpcf7_admin_warnings_bulk_cv( $page, $action, $object ) {
+	if ( 'wpcf7' === $page and 'validate' === $action ) {
+		return;
+	}
+
+	$link = wpcf7_link(
+		add_query_arg(
+			array( 'action' => 'validate' ),
+			menu_page_url( 'wpcf7', false )
+		),
+		__( 'Validate Contact Form 7 Configuration', 'contact-form-7' )
+	);
+
+	$message = __( "Misconfiguration leads to mail delivery failure or other troubles. Validate your contact forms now.", 'contact-form-7' );
+
+	echo sprintf(
+		'<div class="notice notice-warning"><p>%1$s &raquo; %2$s</p></div>',
+		esc_html( $message ),
+		$link
+	);
+}
+
+add_action( 'wpcf7_admin_load', 'wpcf7_load_bulk_validate_page', 10, 2 );
+
+function wpcf7_load_bulk_validate_page( $page, $action ) {
+	if ( 'wpcf7' != $page
+	or 'validate' != $action
+	or ! wpcf7_validate_configuration()
+	or 'POST' != $_SERVER['REQUEST_METHOD'] ) {
+		return;
+	}
+
+	check_admin_referer( 'wpcf7-bulk-validate' );
+
+	if ( ! current_user_can( 'wpcf7_edit_contact_forms' ) ) {
+		wp_die( __( "You are not allowed to validate configuration.", 'contact-form-7' ) );
+	}
+
+	$contact_forms = WPCF7_ContactForm::find();
+
+	$result = array(
+		'timestamp' => current_time( 'timestamp' ),
+		'version' => WPCF7_VERSION,
+		'count_valid' => 0,
+		'count_invalid' => 0,
+	);
+
+	foreach ( $contact_forms as $contact_form ) {
+		$config_validator = new WPCF7_ConfigValidator( $contact_form );
+		$config_validator->validate();
+		$config_validator->save();
+
+		if ( $config_validator->is_valid() ) {
+			$result['count_valid'] += 1;
+		} else {
+			$result['count_invalid'] += 1;
+		}
+	}
+
+	WPCF7::update_option( 'bulk_validate', $result );
+
+	$redirect_to = add_query_arg(
+		array(
+			'message' => 'validated',
+		),
+		menu_page_url( 'wpcf7', false )
+	);
+
+	wp_safe_redirect( $redirect_to );
+	exit();
+}
+
+function wpcf7_admin_bulk_validate_page() {
+	$contact_forms = WPCF7_ContactForm::find();
+	$count = WPCF7_ContactForm::count();
+
+	$submit_text = sprintf(
+		_n(
+			/* translators: %s: number of contact forms */
+			"Validate %s Contact Form Now",
+			"Validate %s Contact Forms Now",
+			$count, 'contact-form-7'
+		),
+		number_format_i18n( $count )
+	);
+
+?>
+<div class="wrap">
+
+<h1><?php echo esc_html( __( 'Validate Configuration', 'contact-form-7' ) ); ?></h1>
+
+<form method="post" action="">
+	<input type="hidden" name="action" value="validate" />
+	<?php wp_nonce_field( 'wpcf7-bulk-validate' ); ?>
+	<p><input type="submit" class="button" value="<?php echo esc_attr( $submit_text ); ?>" /></p>
+</form>
+
+<?php
+	echo wpcf7_link(
+		__( 'https://contactform7.com/configuration-validator-faq/', 'contact-form-7' ),
+		__( 'FAQ about Configuration Validator', 'contact-form-7' )
+	);
+?>
+
+</div>
+<?php
+}

--- a/wp-content/plugins/contact-form-7/admin/includes/editor.php
+++ b/wp-content/plugins/contact-form-7/admin/includes/editor.php
@@ -214,7 +214,7 @@ function wpcf7_editor_panel_messages( $post ) {
 	$messages = wpcf7_messages();
 
 	if ( isset( $messages['captcha_not_match'] )
-	&& ! wpcf7_use_really_simple_captcha() ) {
+	and ! wpcf7_use_really_simple_captcha() ) {
 		unset( $messages['captcha_not_match'] );
 	}
 

--- a/wp-content/plugins/contact-form-7/admin/includes/tag-generator.php
+++ b/wp-content/plugins/contact-form-7/admin/includes/tag-generator.php
@@ -19,7 +19,8 @@ class WPCF7_TagGenerator {
 	public function add( $id, $title, $callback, $options = array() ) {
 		$id = trim( $id );
 
-		if ( '' === $id || ! wpcf7_is_name( $id ) ) {
+		if ( '' === $id
+		or ! wpcf7_is_name( $id ) ) {
 			return false;
 		}
 
@@ -40,11 +41,12 @@ class WPCF7_TagGenerator {
 			echo sprintf(
 				'<a href="#TB_inline?width=900&height=500&inlineId=%1$s" class="thickbox button" title="%2$s">%3$s</a>',
 				esc_attr( $panel['content'] ),
-				/* translators: %s: title of form-tag like 'email' or 'checkboxes' */
 				esc_attr( sprintf(
+					/* translators: %s: title of form-tag like 'email' or 'checkboxes' */
 					__( 'Form-tag Generator: %s', 'contact-form-7' ),
 					$panel['title'] ) ),
-				esc_html( $panel['title'] ) );
+				esc_html( $panel['title'] )
+			);
 		}
 
 		echo '</span>';

--- a/wp-content/plugins/contact-form-7/admin/includes/welcome-panel.php
+++ b/wp-content/plugins/contact-form-7/admin/includes/welcome-panel.php
@@ -23,7 +23,24 @@ function wpcf7_welcome_panel() {
 
 				<p><?php echo esc_html( __( "Spammers target everything; your contact forms aren&#8217;t an exception. Before you get spammed, protect your contact forms with the powerful anti-spam features Contact Form 7 provides.", 'contact-form-7' ) ); ?></p>
 
-				<p><?php /* translators: links labeled 1: 'Akismet', 2: 'reCAPTCHA', 3: 'comment blacklist' */ echo sprintf( esc_html( __( 'Contact Form 7 supports spam-filtering with %1$s. Intelligent %2$s blocks annoying spambots. Plus, using %3$s, you can block messages containing specified keywords or those sent from specified IP addresses.', 'contact-form-7' ) ), wpcf7_link( __( 'https://contactform7.com/spam-filtering-with-akismet/', 'contact-form-7' ), __( 'Akismet', 'contact-form-7' ) ), wpcf7_link( __( 'https://contactform7.com/recaptcha/', 'contact-form-7' ), __( 'reCAPTCHA', 'contact-form-7' ) ), wpcf7_link( __( 'https://contactform7.com/comment-blacklist/', 'contact-form-7' ), __( 'comment blacklist', 'contact-form-7' ) ) ); ?></p>
+				<p><?php
+	echo sprintf(
+		/* translators: links labeled 1: 'Akismet', 2: 'reCAPTCHA', 3: 'comment blacklist' */
+		esc_html( __( 'Contact Form 7 supports spam-filtering with %1$s. Intelligent %2$s blocks annoying spambots. Plus, using %3$s, you can block messages containing specified keywords or those sent from specified IP addresses.', 'contact-form-7' ) ),
+		wpcf7_link(
+			__( 'https://contactform7.com/spam-filtering-with-akismet/', 'contact-form-7' ),
+			__( 'Akismet', 'contact-form-7' )
+		),
+		wpcf7_link(
+			__( 'https://contactform7.com/recaptcha/', 'contact-form-7' ),
+			__( 'reCAPTCHA', 'contact-form-7' )
+		),
+		wpcf7_link(
+			__( 'https://contactform7.com/comment-blacklist/', 'contact-form-7' ),
+			__( 'comment blacklist', 'contact-form-7' )
+		)
+	);
+				?></p>
 			</div>
 
 <?php if ( defined( 'FLAMINGO_VERSION' ) ) : ?>
@@ -32,7 +49,16 @@ function wpcf7_welcome_panel() {
 
 				<p><?php echo esc_html( __( "It is hard to continue development and support for this plugin without contributions from users like you.", 'contact-form-7' ) ); ?></p>
 
-				<p><?php /* translators: %s: link labeled 'making a donation' */ echo sprintf( esc_html( __( 'If you enjoy using Contact Form 7 and find it useful, please consider %s.', 'contact-form-7' ) ), wpcf7_link( __( 'https://contactform7.com/donate/', 'contact-form-7' ), __( 'making a donation', 'contact-form-7' ) ) ); ?></p>
+				<p><?php
+	echo sprintf(
+		/* translators: %s: link labeled 'making a donation' */
+		esc_html( __( 'If you enjoy using Contact Form 7 and find it useful, please consider %s.', 'contact-form-7' ) ),
+		wpcf7_link(
+			__( 'https://contactform7.com/donate/', 'contact-form-7' ),
+			__( 'making a donation', 'contact-form-7' )
+		)
+	);
+				?></p>
 
 				<p><?php echo esc_html( __( "Your donation will help encourage and support the plugin&#8217;s continued development and better user support.", 'contact-form-7' ) ); ?></p>
 			</div>
@@ -42,7 +68,16 @@ function wpcf7_welcome_panel() {
 
 				<p><?php echo esc_html( __( "Contact Form 7 doesn&#8217;t store submitted messages anywhere. Therefore, you may lose important messages forever if your mail server has issues or you make a mistake in mail configuration.", 'contact-form-7' ) ); ?></p>
 
-				<p><?php /* translators: %s: link labeled 'Flamingo' */ echo sprintf( esc_html( __( 'Install a message storage plugin before this happens to you. %s saves all messages through contact forms into the database. Flamingo is a free WordPress plugin created by the same author as Contact Form 7.', 'contact-form-7' ) ), wpcf7_link( __( 'https://contactform7.com/save-submitted-messages-with-flamingo/', 'contact-form-7' ), __( 'Flamingo', 'contact-form-7' ) ) ); ?></p>
+				<p><?php
+	echo sprintf(
+		/* translators: %s: link labeled 'Flamingo' */
+		esc_html( __( 'Install a message storage plugin before this happens to you. %s saves all messages through contact forms into the database. Flamingo is a free WordPress plugin created by the same author as Contact Form 7.', 'contact-form-7' ) ),
+		wpcf7_link(
+			__( 'https://contactform7.com/save-submitted-messages-with-flamingo/', 'contact-form-7' ),
+			__( 'Flamingo', 'contact-form-7' )
+		)
+	);
+				?></p>
 			</div>
 <?php endif; ?>
 
@@ -52,7 +87,8 @@ function wpcf7_welcome_panel() {
 <?php
 }
 
-add_action( 'wp_ajax_wpcf7-update-welcome-panel', 'wpcf7_admin_ajax_welcome_panel' );
+add_action( 'wp_ajax_wpcf7-update-welcome-panel',
+	'wpcf7_admin_ajax_welcome_panel', 10, 0 );
 
 function wpcf7_admin_ajax_welcome_panel() {
 	check_ajax_referer( 'wpcf7-welcome-panel-nonce', 'welcomepanelnonce' );
@@ -60,7 +96,7 @@ function wpcf7_admin_ajax_welcome_panel() {
 	$vers = get_user_meta( get_current_user_id(),
 		'wpcf7_hide_welcome_panel_on', true );
 
-	if ( empty( $vers ) || ! is_array( $vers ) ) {
+	if ( empty( $vers ) or ! is_array( $vers ) ) {
 		$vers = array();
 	}
 
@@ -70,7 +106,8 @@ function wpcf7_admin_ajax_welcome_panel() {
 
 	$vers = array_unique( $vers );
 
-	update_user_meta( get_current_user_id(), 'wpcf7_hide_welcome_panel_on', $vers );
+	update_user_meta( get_current_user_id(),
+		'wpcf7_hide_welcome_panel_on', $vers );
 
 	wp_die( 1 );
 }

--- a/wp-content/plugins/contact-form-7/admin/js/scripts.js
+++ b/wp-content/plugins/contact-form-7/admin/js/scripts.js
@@ -158,7 +158,7 @@
 
 				$.each( errors[ section ], function( i, val ) {
 					var $li = $( '<li></li>' ).append(
-						$( '<span class="dashicons dashicons-warning" aria-hidden="true"></span>' )
+						wpcf7.iconInCircle( '!' )
 					).append(
 						$( '<span class="screen-reader-text"></span>' ).text( wpcf7.configValidator.iconAlt )
 					).append( ' ' );
@@ -191,14 +191,14 @@
 
 		$( '#contact-form-editor-tabs > li' ).each( function() {
 			var $item = $( this );
-			$item.find( 'span.dashicons' ).remove();
+			$item.find( '.icon-in-circle' ).remove();
 			var tab = $item.attr( 'id' ).replace( /-panel-tab$/, '' );
 
 			$.each( errors, function( key, val ) {
 				key = key.replace( /^mail_\d+\./, 'mail.' );
 
 				if ( key.replace( /\..*$/, '' ) == tab.replace( '-', '_' ) ) {
-					var $mark = $( '<span class="dashicons dashicons-warning" aria-hidden="true"></span>' );
+					var $mark = wpcf7.iconInCircle( '!' );
 					$item.find( 'a.ui-tabs-anchor' ).first().append( $mark );
 					return false;
 				}
@@ -208,8 +208,7 @@
 			$tabPanelError.empty();
 
 			if ( errorCount[ tab.replace( '-', '_' ) ] ) {
-				$tabPanelError
-					.append( '<span class="dashicons dashicons-warning" aria-hidden="true"></span> ' );
+				$tabPanelError.append( wpcf7.iconInCircle( '!' ) );
 
 				if ( 1 < errorCount[ tab.replace( '-', '_' ) ] ) {
 					var manyErrorsInTab = wpcf7.configValidator.manyErrorsInTab
@@ -226,7 +225,7 @@
 		if ( errorCount.total ) {
 			var $warning = $( '<div></div>' )
 				.addClass( 'misc-pub-section config-error' )
-				.append( '<span class="dashicons dashicons-warning" aria-hidden="true"></span> ' );
+				.append( wpcf7.iconInCircle( '!' ) );
 
 			if ( 1 < errorCount.total ) {
 				$warning.append(
@@ -272,6 +271,11 @@
 			$titleprompt.addClass( 'screen-reader-text' );
 			$( this ).unbind( e );
 		} );
+	};
+
+	wpcf7.iconInCircle = function( icon ) {
+		var $span = $( '<span class="icon-in-circle" aria-hidden="true"></span>' );
+		return $span.text( icon );
 	};
 
 	wpcf7.apiSettings.getRoute = function( path ) {

--- a/wp-content/plugins/contact-form-7/includes/capabilities.php
+++ b/wp-content/plugins/contact-form-7/includes/capabilities.php
@@ -6,8 +6,10 @@ function wpcf7_map_meta_cap( $caps, $cap, $user_id, $args ) {
 	$meta_caps = array(
 		'wpcf7_edit_contact_form' => WPCF7_ADMIN_READ_WRITE_CAPABILITY,
 		'wpcf7_edit_contact_forms' => WPCF7_ADMIN_READ_WRITE_CAPABILITY,
+		'wpcf7_read_contact_form' => WPCF7_ADMIN_READ_CAPABILITY,
 		'wpcf7_read_contact_forms' => WPCF7_ADMIN_READ_CAPABILITY,
 		'wpcf7_delete_contact_form' => WPCF7_ADMIN_READ_WRITE_CAPABILITY,
+		'wpcf7_delete_contact_forms' => WPCF7_ADMIN_READ_WRITE_CAPABILITY,
 		'wpcf7_manage_integration' => 'manage_options',
 		'wpcf7_submit' => 'read',
 	);

--- a/wp-content/plugins/contact-form-7/includes/config-validator.php
+++ b/wp-content/plugins/contact-form-7/includes/config-validator.php
@@ -12,6 +12,9 @@ class WPCF7_ConfigValidator {
 	const error_unavailable_names = 107;
 	const error_invalid_mail_header = 108;
 	const error_deprecated_settings = 109;
+	const error_file_not_in_content_dir = 110;
+	const error_unavailable_html_elements = 111;
+	const error_attachments_overweight = 112;
 
 	public static function get_doc_link( $error_code = '' ) {
 		$url = __( 'https://contactform7.com/configuration-errors/',
@@ -55,8 +58,8 @@ class WPCF7_ConfigValidator {
 			}
 
 			if ( $args['section']
-			&& $key != $args['section']
-			&& preg_replace( '/\..*$/', '', $key, 1 ) != $args['section'] ) {
+			and $key != $args['section']
+			and preg_replace( '/\..*$/', '', $key, 1 ) != $args['section'] ) {
 				continue;
 			}
 
@@ -65,7 +68,7 @@ class WPCF7_ConfigValidator {
 					continue;
 				}
 
-				if ( $args['code'] && $error['code'] != $args['code'] ) {
+				if ( $args['code'] and $error['code'] != $args['code'] ) {
 					continue;
 				}
 
@@ -169,9 +172,14 @@ class WPCF7_ConfigValidator {
 		}
 
 		foreach ( (array) $this->errors[$section] as $key => $error ) {
-			if ( isset( $error['code'] ) && $error['code'] == $code ) {
+			if ( isset( $error['code'] )
+			and $error['code'] == $code ) {
 				unset( $this->errors[$section][$key] );
 			}
+		}
+
+		if ( empty( $this->errors[$section] ) ) {
+			unset( $this->errors[$section] );
 		}
 	}
 
@@ -268,7 +276,7 @@ class WPCF7_ConfigValidator {
 					$last_item = array_pop( $form_tag->values );
 				}
 
-				if ( $last_item && wpcf7_is_mailbox_list( $last_item ) ) {
+				if ( $last_item and wpcf7_is_mailbox_list( $last_item ) ) {
 					return $example_email;
 				} else {
 					return $example_text;
@@ -317,6 +325,7 @@ class WPCF7_ConfigValidator {
 		$form = $this->contact_form->prop( 'form' );
 		$this->detect_multiple_controls_in_label( $section, $form );
 		$this->detect_unavailable_names( $section, $form );
+		$this->detect_unavailable_html_elements( $section, $form );
 	}
 
 	public function detect_multiple_controls_in_label( $section, $content ) {
@@ -399,6 +408,22 @@ class WPCF7_ConfigValidator {
 		return false;
 	}
 
+	public function detect_unavailable_html_elements( $section, $content ) {
+		$pattern = '%(?:<form[\s\t>]|</form>)%i';
+
+		if ( preg_match( $pattern, $content ) ) {
+			return $this->add_error( $section,
+				self::error_unavailable_html_elements,
+				array(
+					'message' => __( "Unavailable HTML elements are used in the form template.", 'contact-form-7' ),
+					'link' => self::get_doc_link( 'unavailable_html_elements' ),
+				)
+			);
+		}
+
+		return false;
+	}
+
 	public function validate_mail( $template = 'mail' ) {
 		$components = (array) $this->contact_form->prop( $template );
 
@@ -406,7 +431,8 @@ class WPCF7_ConfigValidator {
 			return;
 		}
 
-		if ( 'mail' != $template && empty( $components['active'] ) ) {
+		if ( 'mail' != $template
+		and empty( $components['active'] ) ) {
 			return;
 		}
 
@@ -435,7 +461,7 @@ class WPCF7_ConfigValidator {
 		$sender = wpcf7_strip_newline( $sender );
 
 		if ( ! $this->detect_invalid_mailbox_syntax( sprintf( '%s.sender', $template ), $sender )
-		&& ! wpcf7_is_email_in_site_domain( $sender ) ) {
+		and ! wpcf7_is_email_in_site_domain( $sender ) ) {
 			$this->add_error( sprintf( '%s.sender', $template ),
 				self::error_email_not_in_site_domain, array(
 					'link' => self::get_doc_link( 'email_not_in_site_domain' ),
@@ -501,15 +527,67 @@ class WPCF7_ConfigValidator {
 		$this->detect_maybe_empty( sprintf( '%s.body', $template ), $body );
 
 		if ( '' !== $components['attachments'] ) {
-			foreach ( explode( "\n", $components['attachments'] ) as $line ) {
-				$line = trim( $line );
+			$attachables = array();
 
-				if ( '' === $line || '[' == substr( $line, 0, 1 ) ) {
+			$tags = $this->contact_form->scan_form_tags(
+				array( 'type' => array( 'file', 'file*' ) )
+			);
+
+			foreach ( $tags as $tag ) {
+				$name = $tag->name;
+
+				if ( false === strpos( $components['attachments'], "[{$name}]" ) ) {
 					continue;
 				}
 
-				$this->detect_file_not_found(
-					sprintf( '%s.attachments', $template ), $line );
+				$limit = (int) $tag->get_limit_option();
+
+				if ( empty( $attachables[$name] )
+				or $attachables[$name] < $limit ) {
+					$attachables[$name] = $limit;
+				}
+			}
+
+			$total_size = array_sum( $attachables );
+
+			$has_file_not_found = false;
+			$has_file_not_in_content_dir = false;
+
+			foreach ( explode( "\n", $components['attachments'] ) as $line ) {
+				$line = trim( $line );
+
+				if ( '' === $line
+				or '[' == substr( $line, 0, 1 ) ) {
+					continue;
+				}
+
+				$has_file_not_found = $this->detect_file_not_found(
+					sprintf( '%s.attachments', $template ), $line
+				);
+
+				if ( ! $has_file_not_found
+				and ! $has_file_not_in_content_dir ) {
+					$has_file_not_in_content_dir = $this->detect_file_not_in_content_dir(
+						sprintf( '%s.attachments', $template ), $line
+					);
+				}
+
+				if ( ! $has_file_not_found ) {
+					$path = path_join( WP_CONTENT_DIR, $line );
+					$total_size += (int) @filesize( $path );
+				}
+			}
+
+			$max = 25 * 1024 * 1024; // 25 MB
+
+			if ( $max < $total_size ) {
+				$this->add_error( sprintf( '%s.attachments', $template ),
+					self::error_attachments_overweight,
+					array(
+						'message' => __( "The total size of attachment files is too large.", 'contact-form-7' ),
+						'link' => self::get_doc_link( 'attachments_overweight' ),
+					)
+				);
 			}
 		}
 	}
@@ -544,7 +622,8 @@ class WPCF7_ConfigValidator {
 	public function detect_file_not_found( $section, $content ) {
 		$path = path_join( WP_CONTENT_DIR, $content );
 
-		if ( ! is_readable( $path ) || ! is_file( $path ) ) {
+		if ( ! is_readable( $path )
+		or ! is_file( $path ) ) {
 			return $this->add_error( $section,
 				self::error_file_not_found,
 				array(
@@ -552,6 +631,23 @@ class WPCF7_ConfigValidator {
 						__( "Attachment file does not exist at %path%.", 'contact-form-7' ),
 					'params' => array( 'path' => $content ),
 					'link' => self::get_doc_link( 'file_not_found' ),
+				)
+			);
+		}
+
+		return false;
+	}
+
+	public function detect_file_not_in_content_dir( $section, $content ) {
+		$path = path_join( WP_CONTENT_DIR, $content );
+
+		if ( ! wpcf7_is_file_path_in_content_dir( $path ) ) {
+			return $this->add_error( $section,
+				self::error_file_not_in_content_dir,
+				array(
+					'message' =>
+						__( "It is not allowed to use files outside the wp-content directory.", 'contact-form-7' ),
+					'link' => self::get_doc_link( 'file_not_in_content_dir' ),
 				)
 			);
 		}
@@ -567,7 +663,7 @@ class WPCF7_ConfigValidator {
 		}
 
 		if ( isset( $messages['captcha_not_match'] )
-		&& ! wpcf7_use_really_simple_captcha() ) {
+		and ! wpcf7_use_really_simple_captcha() ) {
 			unset( $messages['captcha_not_match'] );
 		}
 

--- a/wp-content/plugins/contact-form-7/includes/contact-form-functions.php
+++ b/wp-content/plugins/contact-form-7/includes/contact-form-functions.php
@@ -46,7 +46,8 @@ function wpcf7_get_hangover( $name, $default = null ) {
 
 	$submission = WPCF7_Submission::get_instance();
 
-	if ( ! $submission || $submission->is( 'mail_sent' ) ) {
+	if ( ! $submission
+	or $submission->is( 'mail_sent' ) ) {
 		return $default;
 	}
 
@@ -142,6 +143,8 @@ function wpcf7_save_contact_form( $args = '', $context = 'save' ) {
 		'additional_settings' => null,
 	) );
 
+	$args = wp_unslash( $args );
+
 	$args['id'] = (int) $args['id'];
 
 	if ( -1 == $args['id'] ) {
@@ -162,24 +165,30 @@ function wpcf7_save_contact_form( $args = '', $context = 'save' ) {
 		$contact_form->set_locale( $args['locale'] );
 	}
 
-	$properties = $contact_form->get_properties();
+	$properties = array();
 
-	$properties['form'] = wpcf7_sanitize_form(
-		$args['form'], $properties['form'] );
+	if ( null !== $args['form'] ) {
+		$properties['form'] = wpcf7_sanitize_form( $args['form'] );
+	}
 
-	$properties['mail'] = wpcf7_sanitize_mail(
-		$args['mail'], $properties['mail'] );
+	if ( null !== $args['mail'] ) {
+		$properties['mail'] = wpcf7_sanitize_mail( $args['mail'] );
+		$properties['mail']['active'] = true;
+	}
 
-	$properties['mail']['active'] = true;
+	if ( null !== $args['mail_2'] ) {
+		$properties['mail_2'] = wpcf7_sanitize_mail( $args['mail_2'] );
+	}
 
-	$properties['mail_2'] = wpcf7_sanitize_mail(
-		$args['mail_2'], $properties['mail_2'] );
+	if ( null !== $args['messages'] ) {
+		$properties['messages'] = wpcf7_sanitize_messages( $args['messages'] );
+	}
 
-	$properties['messages'] = wpcf7_sanitize_messages(
-		$args['messages'], $properties['messages'] );
-
-	$properties['additional_settings'] = wpcf7_sanitize_additional_settings(
-		$args['additional_settings'], $properties['additional_settings'] );
+	if ( null !== $args['additional_settings'] ) {
+		$properties['additional_settings'] = wpcf7_sanitize_additional_settings(
+			$args['additional_settings']
+		);
+	}
 
 	$contact_form->set_properties( $properties );
 
@@ -202,7 +211,7 @@ function wpcf7_sanitize_form( $input, $default = '' ) {
 }
 
 function wpcf7_sanitize_mail( $input, $defaults = array() ) {
-	$defaults = wp_parse_args( $defaults, array(
+	$input = wp_parse_args( $input, array(
 		'active' => false,
 		'subject' => '',
 		'sender' => '',

--- a/wp-content/plugins/contact-form-7/includes/contact-form-template.php
+++ b/wp-content/plugins/contact-form-7/includes/contact-form-template.php
@@ -47,11 +47,14 @@ class WPCF7_ContactFormTemplate {
 	public static function mail() {
 		$template = array(
 			'subject' =>
-				/* translators: 1: blog name, 2: [your-subject] */
 				sprintf(
+					/* translators: 1: blog name, 2: [your-subject] */
 					_x( '%1$s "%2$s"', 'mail subject', 'contact-form-7' ),
-					get_bloginfo( 'name' ), '[your-subject]' ),
-			'sender' => sprintf( '[your-name] <%s>', self::from_email() ),
+					get_bloginfo( 'name' ),
+					'[your-subject]'
+				),
+			'sender' => sprintf( '%s <%s>',
+				get_bloginfo( 'name' ), self::from_email() ),
 			'body' =>
 				/* translators: %s: [your-name] <[your-email]> */
 				sprintf( __( 'From: %s', 'contact-form-7' ),
@@ -62,11 +65,12 @@ class WPCF7_ContactFormTemplate {
 				. __( 'Message Body:', 'contact-form-7' )
 					. "\n" . '[your-message]' . "\n\n"
 				. '-- ' . "\n"
-				/* translators: 1: blog name, 2: blog URL */
 				. sprintf(
+					/* translators: 1: blog name, 2: blog URL */
 					__( 'This e-mail was sent from a contact form on %1$s (%2$s)', 'contact-form-7' ),
 					get_bloginfo( 'name' ),
-					get_bloginfo( 'url' ) ),
+					get_bloginfo( 'url' )
+				),
 			'recipient' => get_option( 'admin_email' ),
 			'additional_headers' => 'Reply-To: [your-email]',
 			'attachments' => '',
@@ -81,21 +85,24 @@ class WPCF7_ContactFormTemplate {
 		$template = array(
 			'active' => false,
 			'subject' =>
-				/* translators: 1: blog name, 2: [your-subject] */
 				sprintf(
+					/* translators: 1: blog name, 2: [your-subject] */
 					_x( '%1$s "%2$s"', 'mail subject', 'contact-form-7' ),
-					get_bloginfo( 'name' ), '[your-subject]' ),
+					get_bloginfo( 'name' ),
+					'[your-subject]'
+				),
 			'sender' => sprintf( '%s <%s>',
 				get_bloginfo( 'name' ), self::from_email() ),
 			'body' =>
 				__( 'Message Body:', 'contact-form-7' )
 					. "\n" . '[your-message]' . "\n\n"
 				. '-- ' . "\n"
-				/* translators: 1: blog name, 2: blog URL */
 				. sprintf(
+					/* translators: 1: blog name, 2: blog URL */
 					__( 'This e-mail was sent from a contact form on %1$s (%2$s)', 'contact-form-7' ),
 					get_bloginfo( 'name' ),
-					get_bloginfo( 'url' ) ),
+					get_bloginfo( 'url' )
+				),
 			'recipient' => '[your-email]',
 			'additional_headers' => sprintf( 'Reply-To: %s',
 				get_option( 'admin_email' ) ),

--- a/wp-content/plugins/contact-form-7/includes/contact-form.php
+++ b/wp-content/plugins/contact-form-7/includes/contact-form.php
@@ -33,6 +33,17 @@ class WPCF7_ContactForm {
 			),
 			'rewrite' => false,
 			'query_var' => false,
+			'public' => false,
+			'capability_type' => 'page',
+			'capabilities' => array(
+				'edit_post' => 'wpcf7_edit_contact_form',
+				'read_post' => 'wpcf7_read_contact_form',
+				'delete_post' => 'wpcf7_delete_contact_form',
+				'edit_posts' => 'wpcf7_edit_contact_forms',
+				'edit_others_posts' => 'wpcf7_edit_contact_forms',
+				'publish_posts' => 'wpcf7_edit_contact_forms',
+				'read_private_posts' => 'wpcf7_edit_contact_forms',
+			),
 		) );
 	}
 
@@ -103,24 +114,30 @@ class WPCF7_ContactForm {
 	public static function get_instance( $post ) {
 		$post = get_post( $post );
 
-		if ( ! $post || self::post_type != get_post_type( $post ) ) {
+		if ( ! $post
+		or self::post_type != get_post_type( $post ) ) {
 			return false;
 		}
 
 		return self::$current = new self( $post );
 	}
 
-	private static function get_unit_tag( $id = 0 ) {
+	private static function generate_unit_tag( $id = 0 ) {
 		static $global_count = 0;
 
 		$global_count += 1;
 
 		if ( in_the_loop() ) {
 			$unit_tag = sprintf( 'wpcf7-f%1$d-p%2$d-o%3$d',
-				absint( $id ), get_the_ID(), $global_count );
+				absint( $id ),
+				get_the_ID(),
+				$global_count
+			);
 		} else {
 			$unit_tag = sprintf( 'wpcf7-f%1$d-o%2$d',
-				absint( $id ), $global_count );
+				absint( $id ),
+				$global_count
+			);
 		}
 
 		return $unit_tag;
@@ -129,7 +146,8 @@ class WPCF7_ContactForm {
 	private function __construct( $post = null ) {
 		$post = get_post( $post );
 
-		if ( $post && self::post_type == get_post_type( $post ) ) {
+		if ( $post
+		and self::post_type == get_post_type( $post ) ) {
 			$this->id = $post->ID;
 			$this->name = $post->post_name;
 			$this->title = $post->post_title;
@@ -216,6 +234,10 @@ class WPCF7_ContactForm {
 		return $this->id;
 	}
 
+	public function unit_tag() {
+		return $this->unit_tag;
+	}
+
 	public function name() {
 		return $this->name;
 	}
@@ -269,7 +291,7 @@ class WPCF7_ContactForm {
 			return false;
 		}
 
-		return $this->unit_tag == $_POST['_wpcf7_unit_tag'];
+		return $this->unit_tag() === $_POST['_wpcf7_unit_tag'];
 	}
 
 	/* Generating Form HTML */
@@ -290,7 +312,7 @@ class WPCF7_ContactForm {
 		}
 
 		if ( $this->is_true( 'subscribers_only' )
-		&& ! current_user_can( 'wpcf7_submit', $this->id() ) ) {
+		and ! current_user_can( 'wpcf7_submit', $this->id() ) ) {
 			$notice = __(
 				"This contact form is available only for logged in users.",
 				'contact-form-7' );
@@ -301,7 +323,7 @@ class WPCF7_ContactForm {
 			return apply_filters( 'wpcf7_subscribers_only_notice', $notice, $this );
 		}
 
-		$this->unit_tag = self::get_unit_tag( $this->id );
+		$this->unit_tag = self::generate_unit_tag( $this->id );
 
 		$lang_tag = str_replace( '_', '-', $this->locale );
 
@@ -313,7 +335,7 @@ class WPCF7_ContactForm {
 			wpcf7_format_atts( array(
 				'role' => 'form',
 				'class' => 'wpcf7',
-				'id' => $this->unit_tag,
+				'id' => $this->unit_tag(),
 				( get_option( 'html_type' ) == 'text/html' ) ? 'lang' : 'xml:lang'
 					=> $lang_tag,
 				'dir' => wpcf7_is_rtl( $this->locale ) ? 'rtl' : 'ltr',
@@ -328,7 +350,7 @@ class WPCF7_ContactForm {
 			$url = substr( $url, 0, -strlen( $frag ) );
 		}
 
-		$url .= '#' . $this->unit_tag;
+		$url .= '#' . $this->unit_tag();
 
 		$url = apply_filters( 'wpcf7_form_action_url', $url );
 
@@ -428,7 +450,7 @@ class WPCF7_ContactForm {
 			'_wpcf7' => $this->id(),
 			'_wpcf7_version' => WPCF7_VERSION,
 			'_wpcf7_locale' => $this->locale(),
-			'_wpcf7_unit_tag' => $this->unit_tag,
+			'_wpcf7_unit_tag' => $this->unit_tag(),
 			'_wpcf7_container_post' => 0,
 		);
 
@@ -436,7 +458,7 @@ class WPCF7_ContactForm {
 			$hidden_fields['_wpcf7_container_post'] = (int) get_the_ID();
 		}
 
-		if ( $this->nonce_is_active() ) {
+		if ( $this->nonce_is_active() && is_user_logged_in() ) {
 			$hidden_fields['_wpnonce'] = wpcf7_create_nonce();
 		}
 
@@ -455,6 +477,7 @@ class WPCF7_ContactForm {
 	}
 
 	public function form_response_output() {
+		$status = 'init';
 		$class = 'wpcf7-response-output';
 		$role = '';
 		$content = '';
@@ -463,9 +486,10 @@ class WPCF7_ContactForm {
 			$role = 'alert';
 
 			$submission = WPCF7_Submission::get_instance();
+			$status = $submission->get_status();
 			$content = $submission->get_response();
 
-			switch ( $submission->get_status() ) {
+			switch ( $status ) {
 				case 'validation_failed':
 					$class .= ' wpcf7-validation-errors';
 					break;
@@ -486,7 +510,7 @@ class WPCF7_ContactForm {
 					break;
 				default:
 					$class .= sprintf( ' wpcf7-custom-%s',
-						preg_replace( '/[^0-9a-z]+/i', '-', $submission->get_status() )
+						preg_replace( '/[^0-9a-z]+/i', '-', $status )
 					);
 			}
 		} else {
@@ -504,7 +528,7 @@ class WPCF7_ContactForm {
 			$atts, esc_html( $content ) );
 
 		$output = apply_filters( 'wpcf7_form_response_output',
-			$output, $class, $content, $this );
+			$output, $class, $content, $this, $status );
 
 		$this->responses_count += 1;
 
@@ -700,7 +724,7 @@ class WPCF7_ContactForm {
 		) );
 
 		if ( $this->is_true( 'subscribers_only' )
-		&& ! current_user_can( 'wpcf7_submit', $this->id() ) ) {
+		and ! current_user_can( 'wpcf7_submit', $this->id() ) ) {
 			$result = array(
 				'contact_form_id' => $this->id(),
 				'status' => 'error',
@@ -768,7 +792,7 @@ class WPCF7_ContactForm {
 					continue;
 				}
 
-				if ( ! $max || $count < (int) $max ) {
+				if ( ! $max or $count < (int) $max ) {
 					$values[] = trim( $matches[2] );
 					$count += 1;
 				}
@@ -809,7 +833,8 @@ class WPCF7_ContactForm {
 	private function upgrade() {
 		$mail = $this->prop( 'mail' );
 
-		if ( is_array( $mail ) && ! isset( $mail['recipient'] ) ) {
+		if ( is_array( $mail )
+		and ! isset( $mail['recipient'] ) ) {
 			$mail['recipient'] = get_option( 'admin_email' );
 		}
 
@@ -915,6 +940,7 @@ class WPCF7_ContactForm {
 				$this->id, $title );
 		}
 
-		return apply_filters( 'wpcf7_contact_form_shortcode', $shortcode, $args, $this );
+		return apply_filters( 'wpcf7_contact_form_shortcode',
+			$shortcode, $args, $this );
 	}
 }

--- a/wp-content/plugins/contact-form-7/includes/controller.php
+++ b/wp-content/plugins/contact-form-7/includes/controller.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'parse_request', 'wpcf7_control_init', 20 );
+add_action( 'parse_request', 'wpcf7_control_init', 20, 0 );
 
 function wpcf7_control_init() {
 	if ( WPCF7_Submission::is_restful() ) {
@@ -16,21 +16,7 @@ function wpcf7_control_init() {
 	}
 }
 
-add_filter( 'widget_text', 'wpcf7_widget_text_filter', 9 );
-
-function wpcf7_widget_text_filter( $content ) {
-	$pattern = '/\[[\r\n\t ]*contact-form(-7)?[\r\n\t ].*?\]/';
-
-	if ( ! preg_match( $pattern, $content ) ) {
-		return $content;
-	}
-
-	$content = do_shortcode( $content );
-
-	return $content;
-}
-
-add_action( 'wp_enqueue_scripts', 'wpcf7_do_enqueue_scripts' );
+add_action( 'wp_enqueue_scripts', 'wpcf7_do_enqueue_scripts', 10, 0 );
 
 function wpcf7_do_enqueue_scripts() {
 	if ( wpcf7_load_js() ) {
@@ -58,15 +44,9 @@ function wpcf7_enqueue_scripts() {
 			'root' => esc_url_raw( rest_url( 'contact-form-7/v1' ) ),
 			'namespace' => 'contact-form-7/v1',
 		),
-		'recaptcha' => array(
-			'messages' => array(
-				'empty' =>
-					__( 'Please verify that you are not a robot.', 'contact-form-7' ),
-			),
-		),
 	);
 
-	if ( defined( 'WP_CACHE' ) && WP_CACHE ) {
+	if ( defined( 'WP_CACHE' ) and WP_CACHE ) {
 		$wpcf7['cached'] = 1;
 	}
 
@@ -103,7 +83,7 @@ function wpcf7_style_is() {
 
 /* HTML5 Fallback */
 
-add_action( 'wp_enqueue_scripts', 'wpcf7_html5_fallback', 20 );
+add_action( 'wp_enqueue_scripts', 'wpcf7_html5_fallback', 20, 0 );
 
 function wpcf7_html5_fallback() {
 	if ( ! wpcf7_support_html5_fallback() ) {

--- a/wp-content/plugins/contact-form-7/includes/css/styles.css
+++ b/wp-content/plugins/contact-form-7/includes/css/styles.css
@@ -1,8 +1,3 @@
-div.wpcf7 {
-	margin: 0;
-	padding: 0;
-}
-
 div.wpcf7 .screen-reader-response {
 	position: absolute;
 	overflow: hidden;
@@ -95,10 +90,6 @@ div.wpcf7 div.ajax-error {
 
 div.wpcf7 .placeheld {
 	color: #888;
-}
-
-div.wpcf7 .wpcf7-recaptcha iframe {
-	margin-bottom: 0;
 }
 
 div.wpcf7 input[type="file"] {

--- a/wp-content/plugins/contact-form-7/includes/form-tag.php
+++ b/wp-content/plugins/contact-form-7/includes/form-tag.php
@@ -14,7 +14,8 @@ class WPCF7_FormTag implements ArrayAccess {
 	public $content = '';
 
 	public function __construct( $tag = array() ) {
-		if ( is_array( $tag ) || $tag instanceof self ) {
+		if ( is_array( $tag )
+		or $tag instanceof self ) {
 			foreach ( $tag as $key => $value ) {
 				if ( property_exists( __CLASS__, $key ) ) {
 					$this->{$key} = $value;
@@ -104,7 +105,8 @@ class WPCF7_FormTag implements ArrayAccess {
 		$matches_a = $this->get_all_match_options( '%^([0-9]*)/[0-9]*$%' );
 
 		foreach ( (array) $matches_a as $matches ) {
-			if ( isset( $matches[1] ) && '' !== $matches[1] ) {
+			if ( isset( $matches[1] )
+			and '' !== $matches[1] ) {
 				return $matches[1];
 			}
 		}
@@ -171,7 +173,8 @@ class WPCF7_FormTag implements ArrayAccess {
 			'%^([0-9]*)x([0-9]*)(?:/[0-9]+)?$%' );
 
 		foreach ( (array) $matches_a as $matches ) {
-			if ( isset( $matches[2] ) && '' !== $matches[2] ) {
+			if ( isset( $matches[2] )
+			and '' !== $matches[2] ) {
 				return $matches[2];
 			}
 		}
@@ -218,7 +221,8 @@ class WPCF7_FormTag implements ArrayAccess {
 		foreach ( $options as $opt ) {
 			$opt = sanitize_key( $opt );
 
-			if ( 'user_' == substr( $opt, 0, 5 ) && is_user_logged_in() ) {
+			if ( 'user_' == substr( $opt, 0, 5 )
+			and is_user_logged_in() ) {
 				$primary_props = array( 'user_login', 'user_email', 'user_url' );
 				$opt = in_array( $opt, $primary_props ) ? $opt : substr( $opt, 5 );
 
@@ -233,7 +237,7 @@ class WPCF7_FormTag implements ArrayAccess {
 					}
 				}
 
-			} elseif ( 'post_meta' == $opt && in_the_loop() ) {
+			} elseif ( 'post_meta' == $opt and in_the_loop() ) {
 				if ( $args['multiple'] ) {
 					$values = array_merge( $values,
 						get_post_meta( get_the_ID(), $this->name ) );
@@ -245,7 +249,7 @@ class WPCF7_FormTag implements ArrayAccess {
 					}
 				}
 
-			} elseif ( 'get' == $opt && isset( $_GET[$this->name] ) ) {
+			} elseif ( 'get' == $opt and isset( $_GET[$this->name] ) ) {
 				$vals = (array) $_GET[$this->name];
 				$vals = array_map( 'wpcf7_sanitize_query_var', $vals );
 
@@ -259,7 +263,7 @@ class WPCF7_FormTag implements ArrayAccess {
 					}
 				}
 
-			} elseif ( 'post' == $opt && isset( $_POST[$this->name] ) ) {
+			} elseif ( 'post' == $opt and isset( $_POST[$this->name] ) ) {
 				$vals = (array) $_POST[$this->name];
 				$vals = array_map( 'wpcf7_sanitize_query_var', $vals );
 
@@ -316,6 +320,30 @@ class WPCF7_FormTag implements ArrayAccess {
 		$options = (array) $this->get_option( 'data' );
 
 		return apply_filters( 'wpcf7_form_tag_data_option', null, $options, $args );
+	}
+
+	public function get_limit_option( $default = 1048576 ) { // 1048576 = 1 MB
+		$pattern = '/^limit:([1-9][0-9]*)([kKmM]?[bB])?$/';
+
+		$matches = $this->get_first_match_option( $pattern );
+
+		if ( $matches ) {
+			$size = (int) $matches[1];
+
+			if ( ! empty( $matches[2] ) ) {
+				$kbmb = strtolower( $matches[2] );
+
+				if ( 'kb' == $kbmb ) {
+					$size *= 1024;
+				} elseif ( 'mb' == $kbmb ) {
+					$size *= 1024 * 1024;
+				}
+			}
+
+			return $size;
+		}
+
+		return (int) $default;
 	}
 
 	public function get_first_match_option( $pattern ) {

--- a/wp-content/plugins/contact-form-7/includes/form-tags-manager.php
+++ b/wp-content/plugins/contact-form-7/includes/form-tags-manager.php
@@ -141,7 +141,8 @@ class WPCF7_FormTagsManager {
 
 	private function normalize_callback( $m ) {
 		// allow [[foo]] syntax for escaping a tag
-		if ( $m[1] == '[' && $m[6] == ']' ) {
+		if ( $m[1] == '['
+		and $m[6] == ']' ) {
 			return $m[0];
 		}
 
@@ -230,20 +231,20 @@ class WPCF7_FormTagsManager {
 		foreach ( $tags as $tag ) {
 			$tag = new WPCF7_FormTag( $tag );
 
-			if ( $type && ! in_array( $tag->type, $type, true ) ) {
+			if ( $type and ! in_array( $tag->type, $type, true ) ) {
 				continue;
 			}
 
-			if ( $name && ! in_array( $tag->name, $name, true ) ) {
+			if ( $name and ! in_array( $tag->name, $name, true ) ) {
 				continue;
 			}
 
 			if ( $feature ) {
 				if ( ! $this->tag_type_supports( $tag->type, $feature )
-				&& ! $feature_negative ) {
+				and ! $feature_negative ) {
 					continue;
 				} elseif ( $this->tag_type_supports( $tag->type, $feature )
-				&& $feature_negative ) {
+				and $feature_negative ) {
 					continue;
 				}
 			}
@@ -256,7 +257,7 @@ class WPCF7_FormTagsManager {
 
 	private function tag_regex() {
 		$tagnames = array_keys( $this->tag_types );
-		$tagregexp = join( '|', array_map( 'preg_quote', $tagnames ) );
+		$tagregexp = implode( '|', array_map( 'preg_quote', $tagnames ) );
 
 		return '(\[?)'
 			. '\[(' . $tagregexp . ')(?:[\r\n\t ](.*?))?(?:[\r\n\t ](\/))?\]'
@@ -270,7 +271,8 @@ class WPCF7_FormTagsManager {
 
 	private function scan_callback( $m, $replace = false ) {
 		// allow [[foo]] syntax for escaping a tag
-		if ( $m[1] == '[' && $m[6] == ']' ) {
+		if ( $m[1] == '['
+		and $m[6] == ']' ) {
 			return substr( $m[0], 1, -1 );
 		}
 
@@ -293,7 +295,7 @@ class WPCF7_FormTagsManager {
 		if ( is_array( $attr ) ) {
 			if ( is_array( $attr['options'] ) ) {
 				if ( $this->tag_type_supports( $tag, 'name-attr' )
-				&& ! empty( $attr['options'] ) ) {
+				and ! empty( $attr['options'] ) ) {
 					$scanned_tag['name'] = array_shift( $attr['options'] );
 
 					if ( ! wpcf7_is_name( $scanned_tag['name'] ) ) {

--- a/wp-content/plugins/contact-form-7/includes/formatting.php
+++ b/wp-content/plugins/contact-form-7/includes/formatting.php
@@ -164,7 +164,7 @@ function wpcf7_strip_newline( $str ) {
 
 function wpcf7_canonicalize( $text, $strto = 'lower' ) {
 	if ( function_exists( 'mb_convert_kana' )
-	&& 'UTF-8' == get_option( 'blog_charset' ) ) {
+	and 'UTF-8' == get_option( 'blog_charset' ) ) {
 		$text = mb_convert_kana( $text, 'asKV', 'UTF-8' );
 	}
 
@@ -310,7 +310,8 @@ function wpcf7_is_email_in_site_domain( $email ) {
 	$home_url = home_url();
 
 	// for interoperability with WordPress MU Domain Mapping plugin
-	if ( is_multisite() && function_exists( 'domain_mapping_siteurl' ) ) {
+	if ( is_multisite()
+	and function_exists( 'domain_mapping_siteurl' ) ) {
 		$domain_mapping_siteurl = domain_mapping_siteurl( false );
 
 		if ( $domain_mapping_siteurl ) {
@@ -322,7 +323,7 @@ function wpcf7_is_email_in_site_domain( $email ) {
 		$site_domain = strtolower( $matches[1] );
 
 		if ( $site_domain != strtolower( $_SERVER['SERVER_NAME'] )
-		&& wpcf7_is_email_in_domain( $email, $site_domain ) ) {
+		and wpcf7_is_email_in_domain( $email, $site_domain ) ) {
 			return true;
 		}
 	}

--- a/wp-content/plugins/contact-form-7/includes/functions.php
+++ b/wp-content/plugins/contact-form-7/includes/functions.php
@@ -7,7 +7,8 @@ function wpcf7_plugin_path( $path = '' ) {
 function wpcf7_plugin_url( $path = '' ) {
 	$url = plugins_url( $path, WPCF7_PLUGIN );
 
-	if ( is_ssl() && 'http:' == substr( $url, 0, 5 ) ) {
+	if ( is_ssl()
+	and 'http:' == substr( $url, 0, 5 ) ) {
 		$url = 'https:' . substr( $url, 5 );
 	}
 
@@ -51,7 +52,8 @@ function wpcf7_blacklist_check( $target ) {
 	foreach ( (array) $words as $word ) {
 		$word = trim( $word );
 
-		if ( empty( $word ) || 256 < strlen( $word ) ) {
+		if ( empty( $word )
+		or 256 < strlen( $word ) ) {
 			continue;
 		}
 
@@ -253,17 +255,23 @@ function wpcf7_enctype_value( $enctype ) {
 
 function wpcf7_rmdir_p( $dir ) {
 	if ( is_file( $dir ) ) {
-		if ( ! $result = unlink( $dir ) ) {
-			$stat = stat( $dir );
-			$perms = $stat['mode'];
-			chmod( $dir, $perms | 0200 ); // add write for owner
+		$file = $dir;
 
-			if ( ! $result = unlink( $dir ) ) {
-				chmod( $dir, $perms );
-			}
+		if ( @unlink( $file ) ) {
+			return true;
 		}
 
-		return $result;
+		$stat = stat( $file );
+
+		if ( @chmod( $file, $stat['mode'] | 0200 ) ) { // add write for owner
+			if ( @unlink( $file ) ) {
+				return true;
+			}
+
+			@chmod( $file, $stat['mode'] );
+		}
+
+		return false;
 	}
 
 	if ( ! is_dir( $dir ) ) {
@@ -272,7 +280,8 @@ function wpcf7_rmdir_p( $dir ) {
 
 	if ( $handle = opendir( $dir ) ) {
 		while ( false !== ( $file = readdir( $handle ) ) ) {
-			if ( $file == "." || $file == ".." ) {
+			if ( $file == "."
+			or $file == ".." ) {
 				continue;
 			}
 
@@ -283,7 +292,7 @@ function wpcf7_rmdir_p( $dir ) {
 	}
 
 	if ( false !== ( $files = scandir( $dir ) )
-	&& ! array_diff( $files, array( '.', '..' ) ) ) {
+	and ! array_diff( $files, array( '.', '..' ) ) ) {
 		return rmdir( $dir );
 	}
 
@@ -308,7 +317,7 @@ function wpcf7_build_query( $args, $key = '' ) {
 			$v = '0';
 		}
 
-		if ( is_array( $v ) || is_object( $v ) ) {
+		if ( is_array( $v ) or is_object( $v ) ) {
 			array_push( $ret, wpcf7_build_query( $v, $k ) );
 		} else {
 			array_push( $ret, $k . '=' . urlencode( $v ) );
@@ -360,7 +369,7 @@ function wpcf7_is_localhost() {
 function wpcf7_deprecated_function( $function, $version, $replacement ) {
 	$trigger_error = apply_filters( 'deprecated_function_trigger_error', true );
 
-	if ( WP_DEBUG && $trigger_error ) {
+	if ( WP_DEBUG and $trigger_error ) {
 		if ( function_exists( '__' ) ) {
 			trigger_error( sprintf( __( '%1$s is <strong>deprecated</strong> since Contact Form 7 version %2$s! Use %3$s instead.', 'contact-form-7' ), $function, $version, $replacement ) );
 		} else {
@@ -369,8 +378,28 @@ function wpcf7_deprecated_function( $function, $version, $replacement ) {
 	}
 }
 
+function wpcf7_log_remote_request( $url, $request, $response ) {
+	$log = sprintf(
+		/* translators: 1: response code, 2: message, 3: body, 4: URL */
+		__( 'HTTP Response: %1$s %2$s %3$s from %4$s', 'contact-form-7' ),
+		(int) wp_remote_retrieve_response_code( $response ),
+		wp_remote_retrieve_response_message( $response ),
+		wp_remote_retrieve_body( $response ),
+		$url
+	);
+
+	$log = apply_filters( 'wpcf7_log_remote_request',
+		$log, $url, $request, $response
+	);
+
+	if ( $log ) {
+		trigger_error( $log );
+	}
+}
+
 function wpcf7_anonymize_ip_addr( $ip_addr ) {
-	if ( ! function_exists( 'inet_ntop' ) || ! function_exists( 'inet_pton' ) ) {
+	if ( ! function_exists( 'inet_ntop' )
+	or ! function_exists( 'inet_pton' ) ) {
 		return $ip_addr;
 	}
 
@@ -389,4 +418,17 @@ function wpcf7_anonymize_ip_addr( $ip_addr ) {
 	}
 
 	return inet_ntop( $packed & inet_pton( $mask ) );
+}
+
+function wpcf7_is_file_path_in_content_dir( $path ) {
+	if ( 0 === strpos( realpath( $path ), realpath( WP_CONTENT_DIR ) ) ) {
+		return true;
+	}
+
+	if ( defined( 'UPLOADS' )
+	and 0 === strpos( realpath( $path ), realpath( ABSPATH . UPLOADS ) ) ) {
+		return true;
+	}
+
+	return false;
 }

--- a/wp-content/plugins/contact-form-7/includes/integration.php
+++ b/wp-content/plugins/contact-form-7/includes/integration.php
@@ -20,7 +20,8 @@ class WPCF7_Integration {
 	public function add_service( $name, WPCF7_Service $service ) {
 		$name = sanitize_key( $name );
 
-		if ( empty( $name ) || isset( $this->services[$name] ) ) {
+		if ( empty( $name )
+		or isset( $this->services[$name] ) ) {
 			return false;
 		}
 
@@ -30,7 +31,8 @@ class WPCF7_Integration {
 	public function add_category( $name, $title ) {
 		$name = sanitize_key( $name );
 
-		if ( empty( $name ) || isset( $this->categories[$name] ) ) {
+		if ( empty( $name )
+		or isset( $this->categories[$name] ) ) {
 			return false;
 		}
 
@@ -130,6 +132,214 @@ abstract class WPCF7_Service {
 	}
 
 	public function admin_notice( $message = '' ) {
+	}
+
+}
+
+class WPCF7_Service_OAuth2 extends WPCF7_Service {
+
+	protected $client_id = '';
+	protected $client_secret = '';
+	protected $access_token = '';
+	protected $refresh_token = '';
+	protected $authorization_endpoint = 'https://example.com/authorization';
+	protected $token_endpoint = 'https://example.com/token';
+
+	public function get_title() {
+		return '';
+	}
+
+	public function is_active() {
+		return ! empty( $this->refresh_token );
+	}
+
+	protected function save_data() {
+	}
+
+	protected function reset_data() {
+	}
+
+	protected function get_redirect_uri() {
+		return admin_url();
+	}
+
+	protected function menu_page_url( $args = '' ) {
+		return menu_page_url( 'wpcf7-integration', false );
+	}
+
+	public function load( $action = '' ) {
+		if ( 'auth_redirect' == $action ) {
+			$code = isset( $_GET['code'] ) ? $_GET['code'] : '';
+
+			if ( $code ) {
+				$this->request_token( $code );
+			}
+
+			if ( ! empty( $this->access_token ) ) {
+				$message = 'success';
+			} else {
+				$message = 'failed';
+			}
+
+			wp_safe_redirect( $this->menu_page_url(
+				array(
+					'action' => 'setup',
+					'message' => $message,
+				)
+			) );
+
+			exit();
+		}
+	}
+
+	protected function authorize( $scope = '' ) {
+		$endpoint = add_query_arg(
+			array(
+				'response_type' => 'code',
+				'client_id' => $this->client_id,
+				'redirect_uri' => urlencode( $this->get_redirect_uri() ),
+				'scope' => $scope,
+			),
+			$this->authorization_endpoint
+		);
+
+		if ( wp_redirect( esc_url_raw( $endpoint ) ) ) {
+			exit();
+		}
+	}
+
+	protected function get_http_authorization_header( $scheme = 'basic' ) {
+		$scheme = strtolower( trim( $scheme ) );
+
+		switch ( $scheme ) {
+			case 'bearer':
+				return sprintf( 'Bearer %s', $this->access_token );
+			case 'basic':
+			default:
+				return sprintf( 'Basic %s',
+					base64_encode( $this->client_id . ':' . $this->client_secret )
+				);
+		}
+	}
+
+	protected function request_token( $authorization_code ) {
+		$endpoint = add_query_arg(
+			array(
+				'code' => $authorization_code,
+				'redirect_uri' => urlencode( $this->get_redirect_uri() ),
+				'grant_type' => 'authorization_code',
+			),
+			$this->token_endpoint
+		);
+
+		$request = array(
+			'headers' => array(
+				'Authorization' => $this->get_http_authorization_header( 'basic' ),
+			),
+		);
+
+		$response = wp_remote_post( esc_url_raw( $endpoint ), $request );
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
+		$response_body = json_decode( $response_body, true );
+
+		if ( WP_DEBUG and 400 <= $response_code ) {
+			$this->log( $endpoint, $request, $response );
+		}
+
+		if ( 401 == $response_code ) { // Unauthorized
+			$this->access_token = null;
+			$this->refresh_token = null;
+		} else {
+			if ( isset( $response_body['access_token'] ) ) {
+				$this->access_token = $response_body['access_token'];
+			} else {
+				$this->access_token = null;
+			}
+
+			if ( isset( $response_body['refresh_token'] ) ) {
+				$this->refresh_token = $response_body['refresh_token'];
+			} else {
+				$this->refresh_token = null;
+			}
+		}
+
+		$this->save_data();
+
+		return $response;
+	}
+
+	protected function refresh_token() {
+		$endpoint = add_query_arg(
+			array(
+				'refresh_token' => $this->refresh_token,
+				'grant_type' => 'refresh_token',
+			),
+			$this->token_endpoint
+		);
+
+		$request = array(
+			'headers' => array(
+				'Authorization' => $this->get_http_authorization_header( 'basic' ),
+			),
+		);
+
+		$response = wp_remote_post( esc_url_raw( $endpoint ), $request );
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
+		$response_body = json_decode( $response_body, true );
+
+		if ( WP_DEBUG and 400 <= $response_code ) {
+			$this->log( $endpoint, $request, $response );
+		}
+
+		if ( 401 == $response_code ) { // Unauthorized
+			$this->access_token = null;
+			$this->refresh_token = null;
+		} else {
+			if ( isset( $response_body['access_token'] ) ) {
+				$this->access_token = $response_body['access_token'];
+			} else {
+				$this->access_token = null;
+			}
+
+			if ( isset( $response_body['refresh_token'] ) ) {
+				$this->refresh_token = $response_body['refresh_token'];
+			}
+		}
+
+		$this->save_data();
+
+		return $response;
+	}
+
+	protected function remote_request( $url, $request = array() ) {
+		static $refreshed = false;
+
+		$request = wp_parse_args( $request, array() );
+
+		$request['headers'] = array_merge(
+			$request['headers'],
+			array(
+				'Authorization' => $this->get_http_authorization_header( 'bearer' ),
+			)
+		);
+
+		$response = wp_remote_request( esc_url_raw( $url ), $request );
+
+		if ( 401 === wp_remote_retrieve_response_code( $response )
+		and ! $refreshed ) {
+			$this->refresh_token();
+			$refreshed = true;
+
+			$response = $this->remote_request( $url, $request );
+		}
+
+		return $response;
+	}
+
+	protected function log( $url, $request, $response ) {
+		wpcf7_log_remote_request( $url, $request, $response );
 	}
 
 }

--- a/wp-content/plugins/contact-form-7/includes/js/scripts.js
+++ b/wp-content/plugins/contact-form-7/includes/js/scripts.js
@@ -46,12 +46,16 @@
 		var $form = $( form );
 
 		$form.submit( function( event ) {
-			if ( typeof window.FormData !== 'function' ) {
-				return;
+			if ( ! wpcf7.supportHtml5.placeholder ) {
+				$( '[placeholder].placeheld', $form ).each( function( i, n ) {
+					$( n ).val( '' ).removeClass( 'placeheld' );
+				} );
 			}
 
-			wpcf7.submit( $form );
-			event.preventDefault();
+			if ( typeof window.FormData === 'function' ) {
+				wpcf7.submit( $form );
+				event.preventDefault();
+			}
 		} );
 
 		$( '.wpcf7-submit', $form ).after( '<span class="ajax-loader"></span>' );
@@ -193,10 +197,6 @@
 
 		$( '.ajax-loader', $form ).addClass( 'is-active' );
 
-		$( '[placeholder].placeheld', $form ).each( function( i, n ) {
-			$( n ).val( '' );
-		} );
-
 		wpcf7.clearResponse( $form );
 
 		var formData = new FormData( $form.get( 0 ) );
@@ -266,13 +266,6 @@
 					$message.addClass( 'wpcf7-spam-blocked' );
 					$form.addClass( 'spam' );
 
-					$( '[name="g-recaptcha-response"]', $form ).each( function() {
-						if ( '' === $( this ).val() ) {
-							var $recaptcha = $( this ).closest( '.wpcf7-form-control-wrap' );
-							wpcf7.notValidTip( $recaptcha, wpcf7.recaptcha.messages.empty );
-						}
-					} );
-
 					wpcf7.triggerEvent( data.into, 'spam', detail );
 					break;
 				case 'aborted':
@@ -312,9 +305,11 @@
 				wpcf7.toggleSubmit( $form );
 			}
 
-			$form.find( '[placeholder].placeheld' ).each( function( i, n ) {
-				$( n ).val( $( n ).attr( 'placeholder' ) );
-			} );
+			if ( ! wpcf7.supportHtml5.placeholder ) {
+				$form.find( '[placeholder].placeheld' ).each( function( i, n ) {
+					$( n ).val( $( n ).attr( 'placeholder' ) );
+				} );
+			}
 
 			$message.html( '' ).append( data.message ).slideDown( 'fast' );
 			$message.attr( 'role', 'alert' );

--- a/wp-content/plugins/contact-form-7/includes/l10n.php
+++ b/wp-content/plugins/contact-form-7/includes/l10n.php
@@ -18,13 +18,14 @@ function wpcf7_l10n() {
 		'version' => WPCF7_VERSION,
 	) );
 
-	if ( is_wp_error( $api ) || empty( $api['translations'] ) ) {
+	if ( is_wp_error( $api )
+	or empty( $api['translations'] ) ) {
 		return $l10n;
 	}
 
 	foreach ( (array) $api['translations'] as $translation ) {
 		if ( ! empty( $translation['language'] )
-		&& ! empty( $translation['english_name'] ) ) {
+		and ! empty( $translation['english_name'] ) ) {
 			$l10n[$translation['language']] = $translation['english_name'];
 		}
 	}
@@ -49,7 +50,8 @@ function wpcf7_is_rtl( $locale = '' ) {
 		'ug_CN' => 'Uighur',
 	);
 
-	if ( empty( $locale ) && function_exists( 'is_rtl' ) ) {
+	if ( empty( $locale )
+	and function_exists( 'is_rtl' ) ) {
 		return is_rtl();
 	}
 

--- a/wp-content/plugins/contact-form-7/includes/mail.php
+++ b/wp-content/plugins/contact-form-7/includes/mail.php
@@ -57,7 +57,7 @@ class WPCF7_Mail {
 			) );
 
 			if ( $use_html
-			&& ! preg_match( '%<html[>\s].*</html>%is', $component ) ) {
+			and ! preg_match( '%<html[>\s].*</html>%is', $component ) ) {
 				$component = $this->htmlize( $component );
 			}
 		}
@@ -159,7 +159,7 @@ class WPCF7_Mail {
 
 			foreach ( (array) $uploaded_files as $name => $path ) {
 				if ( false !== strpos( $template, "[${name}]" )
-				&& ! empty( $path ) ) {
+				and ! empty( $path ) ) {
 					$attachments[] = $path;
 				}
 			}
@@ -174,7 +174,13 @@ class WPCF7_Mail {
 
 			$path = path_join( WP_CONTENT_DIR, $line );
 
-			if ( is_readable( $path ) && is_file( $path ) ) {
+			if ( ! wpcf7_is_file_path_in_content_dir( $path ) ) {
+				// $path is out of WP_CONTENT_DIR
+				continue;
+			}
+
+			if ( is_readable( $path )
+			and is_file( $path ) ) {
 				$attachments[] = $path;
 			}
 		}
@@ -206,7 +212,8 @@ function wpcf7_mail_replace_tags( $content, $args = '' ) {
 		if ( $args['exclude_blank'] ) {
 			$replaced_tags = $line->get_replaced_tags();
 
-			if ( empty( $replaced_tags ) || array_filter( $replaced_tags ) ) {
+			if ( empty( $replaced_tags )
+			or array_filter( $replaced_tags, 'strlen' ) ) {
 				$content[$num] = $replaced;
 			} else {
 				unset( $content[$num] ); // Remove a line.
@@ -221,7 +228,7 @@ function wpcf7_mail_replace_tags( $content, $args = '' ) {
 	return $content;
 }
 
-add_action( 'phpmailer_init', 'wpcf7_phpmailer_init' );
+add_action( 'phpmailer_init', 'wpcf7_phpmailer_init', 10, 1 );
 
 function wpcf7_phpmailer_init( $phpmailer ) {
 	$custom_headers = $phpmailer->getCustomHeaders();
@@ -261,7 +268,8 @@ class WPCF7_MailTaggedText {
 
 		$this->html = (bool) $args['html'];
 
-		if ( null !== $args['callback'] && is_callable( $args['callback'] ) ) {
+		if ( null !== $args['callback']
+		and is_callable( $args['callback'] ) ) {
 			$this->callback = $args['callback'];
 		} elseif ( $this->html ) {
 			$this->callback = array( $this, 'replace_tags_callback_html' );
@@ -291,7 +299,8 @@ class WPCF7_MailTaggedText {
 
 	private function replace_tags_callback( $matches, $html = false ) {
 		// allow [[foo]] syntax for escaping a tag
-		if ( $matches[1] == '[' && $matches[4] == ']' ) {
+		if ( $matches[1] == '['
+		and $matches[4] == ']' ) {
 			return substr( $matches[0], 1, -1 );
 		}
 

--- a/wp-content/plugins/contact-form-7/includes/rest-api.php
+++ b/wp-content/plugins/contact-form-7/includes/rest-api.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'rest_api_init', 'wpcf7_rest_api_init' );
+add_action( 'rest_api_init', 'wpcf7_rest_api_init', 10, 0 );
 
 function wpcf7_rest_api_init() {
 	$namespace = 'contact-form-7/v1';
@@ -268,8 +268,13 @@ function wpcf7_rest_delete_contact_form( WP_REST_Request $request ) {
 }
 
 function wpcf7_rest_create_feedback( WP_REST_Request $request ) {
-	$id = (int) $request->get_param( 'id' );
-	$item = wpcf7_contact_form( $id );
+	$url_params = $request->get_url_params();
+
+	$item = null;
+
+	if ( ! empty( $url_params['id'] ) ) {
+		$item = wpcf7_contact_form( $url_params['id'] );
+	}
 
 	if ( ! $item ) {
 		return new WP_Error( 'wpcf7_not_found',

--- a/wp-content/plugins/contact-form-7/includes/special-mail-tags.php
+++ b/wp-content/plugins/contact-form-7/includes/special-mail-tags.php
@@ -39,7 +39,8 @@ function wpcf7_special_mail_tag( $output, $name, $html ) {
 		}
 	}
 
-	if ( '_date' == $name || '_time' == $name ) {
+	if ( '_date' == $name
+	or '_time' == $name ) {
 		if ( $timestamp = $submission->get_meta( 'timestamp' ) ) {
 			if ( '_date' == $name ) {
 				return date_i18n( get_option( 'date_format' ), $timestamp );
@@ -75,7 +76,8 @@ function wpcf7_post_related_smt( $output, $name, $html ) {
 
 	$post_id = (int) $submission->get_meta( 'container_post_id' );
 
-	if ( ! $post_id || ! $post = get_post( $post_id ) ) {
+	if ( ! $post_id
+	or ! $post = get_post( $post_id ) ) {
 		return '';
 	}
 
@@ -135,7 +137,8 @@ function wpcf7_site_related_smt( $output, $name, $html ) {
 add_filter( 'wpcf7_special_mail_tags', 'wpcf7_user_related_smt', 10, 3 );
 
 function wpcf7_user_related_smt( $output, $name, $html ) {
-	if ( '_user_' != substr( $name, 0, 6 ) || '_user_agent' == $name ) {
+	if ( '_user_' != substr( $name, 0, 6 )
+	or '_user_agent' == $name ) {
 		return $output;
 	}
 

--- a/wp-content/plugins/contact-form-7/includes/submission.php
+++ b/wp-content/plugins/contact-form-7/includes/submission.php
@@ -13,6 +13,7 @@ class WPCF7_Submission {
 	private $invalid_fields = array();
 	private $meta = array();
 	private $consent = array();
+	private $spam_log = array();
 
 	private function __construct() {}
 
@@ -119,8 +120,8 @@ class WPCF7_Submission {
 			}
 
 			if ( WPCF7_USE_PIPE
-			&& $pipes instanceof WPCF7_Pipes
-			&& ! $pipes->zero() ) {
+			and $pipes instanceof WPCF7_Pipes
+			and ! $pipes->zero() ) {
 				if ( is_array( $value_orig ) ) {
 					$value = array();
 
@@ -138,7 +139,7 @@ class WPCF7_Submission {
 			$posted_data[$name] = $value;
 
 			if ( $tag->has_option( 'consent_for:storage' )
-			&& empty( $posted_data[$name] ) ) {
+			and empty( $posted_data[$name] ) ) {
 				$this->meta['do_not_store'] = true;
 			}
 		}
@@ -228,7 +229,7 @@ class WPCF7_Submission {
 		$ip_addr = '';
 
 		if ( isset( $_SERVER['REMOTE_ADDR'] )
-		&& WP_Http::is_ip_address( $_SERVER['REMOTE_ADDR'] ) ) {
+		and WP_Http::is_ip_address( $_SERVER['REMOTE_ADDR'] ) ) {
 			$ip_addr = $_SERVER['REMOTE_ADDR'];
 		}
 
@@ -242,7 +243,8 @@ class WPCF7_Submission {
 			$referer = isset( $_SERVER['HTTP_REFERER'] )
 				? trim( $_SERVER['HTTP_REFERER'] ) : '';
 
-			if ( $referer && 0 === strpos( $referer, $home_url ) ) {
+			if ( $referer
+			and 0 === strpos( $referer, $home_url ) ) {
 				return esc_url_raw( $referer );
 			}
 		}
@@ -292,7 +294,7 @@ class WPCF7_Submission {
 		$spam = false;
 
 		if ( $this->contact_form->is_true( 'subscribers_only' )
-		&& current_user_can( 'wpcf7_submit', $this->contact_form->id() ) ) {
+		and current_user_can( 'wpcf7_submit', $this->contact_form->id() ) ) {
 			return $spam;
 		}
 
@@ -300,17 +302,45 @@ class WPCF7_Submission {
 
 		if ( strlen( $user_agent ) < 2 ) {
 			$spam = true;
+
+			$this->add_spam_log( array(
+				'agent' => 'wpcf7',
+				'reason' => __( "User-Agent string is unnaturally short.", 'contact-form-7' ),
+			) );
 		}
 
 		if ( ! $this->verify_nonce() ) {
 			$spam = true;
+
+			$this->add_spam_log( array(
+				'agent' => 'wpcf7',
+				'reason' => __( "Submitted nonce is invalid.", 'contact-form-7' ),
+			) );
 		}
 
 		if ( $this->is_blacklisted() ) {
 			$spam = true;
+
+			$this->add_spam_log( array(
+				'agent' => 'wpcf7',
+				'reason' => __( "Blacklisted words are used.", 'contact-form-7' ),
+			) );
 		}
 
 		return apply_filters( 'wpcf7_spam', $spam );
+	}
+
+	public function add_spam_log( $args = '' ) {
+		$args = wp_parse_args( $args, array(
+			'agent' => '',
+			'reason' => '',
+		) );
+
+		$this->spam_log[] = $args;
+	}
+
+	public function get_spam_log() {
+		return $this->spam_log;
 	}
 
 	private function verify_nonce() {
@@ -360,7 +390,8 @@ class WPCF7_Submission {
 		if ( $result ) {
 			$additional_mail = array();
 
-			if ( ( $mail_2 = $contact_form->prop( 'mail_2' ) ) && $mail_2['active'] ) {
+			if ( $mail_2 = $contact_form->prop( 'mail_2' )
+			and $mail_2['active'] ) {
 				$additional_mail['mail_2'] = $mail_2;
 			}
 
@@ -393,9 +424,9 @@ class WPCF7_Submission {
 		foreach ( (array) $this->uploaded_files as $name => $path ) {
 			wpcf7_rmdir_p( $path );
 
-			if ( ( $dir = dirname( $path ) )
-			&& false !== ( $files = scandir( $dir ) )
-			&& ! array_diff( $files, array( '.', '..' ) ) ) {
+			if ( $dir = dirname( $path )
+			and false !== ( $files = scandir( $dir ) )
+			and ! array_diff( $files, array( '.', '..' ) ) ) {
 				// remove parent dir if it's empty.
 				rmdir( $dir );
 			}

--- a/wp-content/plugins/contact-form-7/includes/upgrade.php
+++ b/wp-content/plugins/contact-form-7/includes/upgrade.php
@@ -15,9 +15,13 @@ function wpcf7_convert_to_cpt( $new_ver, $old_ver ) {
 
 	if ( $wpdb->get_var( "SHOW TABLES LIKE '$table_name'" ) ) {
 		$old_rows = $wpdb->get_results( "SELECT * FROM $table_name" );
-	} elseif ( ( $opt = get_option( 'wpcf7' ) ) && ! empty( $opt['contact_forms'] ) ) {
+	} elseif ( $opt = get_option( 'wpcf7' )
+	and ! empty( $opt['contact_forms'] ) ) {
 		foreach ( (array) $opt['contact_forms'] as $key => $value ) {
-			$old_rows[] = (object) array_merge( $value, array( 'cf7_unit_id' => $key ) );
+			$old_rows[] = (object) array_merge(
+				$value,
+				array( 'cf7_unit_id' => $key )
+			);
 		}
 	}
 

--- a/wp-content/plugins/contact-form-7/includes/validation.php
+++ b/wp-content/plugins/contact-form-7/includes/validation.php
@@ -24,14 +24,16 @@ class WPCF7_Validation implements ArrayAccess {
 
 		$name = ! empty( $tag ) ? $tag->name : null;
 
-		if ( empty( $name ) || ! wpcf7_is_name( $name ) ) {
+		if ( empty( $name )
+		or ! wpcf7_is_name( $name ) ) {
 			return;
 		}
 
 		if ( $this->is_valid( $name ) ) {
 			$id = $tag->get_id_option();
 
-			if ( empty( $id ) || ! wpcf7_is_name( $id ) ) {
+			if ( empty( $id )
+			or ! wpcf7_is_name( $id ) ) {
 				$id = null;
 			}
 
@@ -59,7 +61,8 @@ class WPCF7_Validation implements ArrayAccess {
 			$this->container[$offset] = $value;
 		}
 
-		if ( 'reason' == $offset && is_array( $value ) ) {
+		if ( 'reason' == $offset
+		and is_array( $value ) ) {
 			foreach ( $value as $k => $v ) {
 				$this->invalidate( $k, $v );
 			}

--- a/wp-content/plugins/contact-form-7/license.txt
+++ b/wp-content/plugins/contact-form-7/license.txt
@@ -1,4 +1,4 @@
-Contact Form 7 WordPress Plugin, 2007-2018 Takayuki Miyoshi
+Contact Form 7 WordPress Plugin, 2007-2019 Takayuki Miyoshi
 Contact Form 7 is distributed under the terms of the GNU GPL
 
 This program is free software; you can redistribute it and/or modify

--- a/wp-content/plugins/contact-form-7/modules/acceptance.php
+++ b/wp-content/plugins/contact-form-7/modules/acceptance.php
@@ -5,14 +5,13 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_acceptance' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_acceptance', 10, 0 );
 
 function wpcf7_add_form_tag_acceptance() {
 	wpcf7_add_form_tag( 'acceptance',
 		'wpcf7_acceptance_form_tag_handler',
 		array(
 			'name-attr' => true,
-			'do-not-store' => true,
 		)
 	);
 }
@@ -66,9 +65,21 @@ function wpcf7_acceptance_form_tag_handler( $tag ) {
 	$content = trim( $content );
 
 	if ( $content ) {
+		if ( $tag->has_option( 'label_first' ) ) {
+			$html = sprintf(
+				'<span class="wpcf7-list-item-label">%2$s</span><input %1$s />',
+				$item_atts, $content );
+		} else {
+			$html = sprintf(
+				'<input %1$s /><span class="wpcf7-list-item-label">%2$s</span>',
+				$item_atts, $content );
+		}
+
 		$html = sprintf(
-			'<span class="wpcf7-list-item"><label><input %1$s /><span class="wpcf7-list-item-label">%2$s</span></label></span>',
-			$item_atts, $content );
+			'<span class="wpcf7-list-item"><label>%s</label></span>',
+			$html
+		);
+
 	} else {
 		$html = sprintf(
 			'<span class="wpcf7-list-item"><input %1$s /></span>',
@@ -104,7 +115,8 @@ function wpcf7_acceptance_validation_filter( $result, $tag ) {
 
 	$invert = $tag->has_option( 'invert' );
 
-	if ( $invert && $value || ! $invert && ! $value ) {
+	if ( $invert and $value
+	or ! $invert and ! $value ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'accept_terms' ) );
 	}
 
@@ -134,7 +146,7 @@ function wpcf7_acceptance_filter( $accepted, $submission ) {
 
 		$content = trim( $content );
 
-		if ( $value && $content ) {
+		if ( $value and $content ) {
 			$submission->add_consent( $name, $content );
 		}
 
@@ -144,7 +156,8 @@ function wpcf7_acceptance_filter( $accepted, $submission ) {
 
 		$invert = $tag->has_option( 'invert' );
 
-		if ( $invert && $value || ! $invert && ! $value ) {
+		if ( $invert and $value
+		or ! $invert and ! $value ) {
 			$accepted = false;
 		}
 	}
@@ -152,7 +165,8 @@ function wpcf7_acceptance_filter( $accepted, $submission ) {
 	return $accepted;
 }
 
-add_filter( 'wpcf7_form_class_attr', 'wpcf7_acceptance_form_class_attr' );
+add_filter( 'wpcf7_form_class_attr',
+	'wpcf7_acceptance_form_class_attr', 10, 1 );
 
 function wpcf7_acceptance_form_class_attr( $class ) {
 	if ( wpcf7_acceptance_as_validation() ) {
@@ -197,12 +211,13 @@ function wpcf7_acceptance_mail_tag( $replaced, $submitted, $html, $mail_tag ) {
 	$content = trim( $content );
 
 	if ( $content ) {
-		/* translators: 1: 'Consented' or 'Not consented', 2: conditions */
 		$replaced = sprintf(
+			/* translators: 1: 'Consented' or 'Not consented', 2: conditions */
 			_x( '%1$s: %2$s', 'mail output for acceptance checkboxes',
 				'contact-form-7' ),
 			$replaced,
-			$content );
+			$content
+		);
 	}
 
 	return $replaced;
@@ -211,7 +226,7 @@ function wpcf7_acceptance_mail_tag( $replaced, $submitted, $html, $mail_tag ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_acceptance', 35 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_acceptance', 35, 0 );
 
 function wpcf7_add_tag_generator_acceptance() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/akismet.php
+++ b/wp-content/plugins/contact-form-7/modules/akismet.php
@@ -4,7 +4,7 @@
 ** Akismet API: http://akismet.com/development/api/
 **/
 
-add_filter( 'wpcf7_spam', 'wpcf7_akismet' );
+add_filter( 'wpcf7_spam', 'wpcf7_akismet', 10, 1 );
 
 function wpcf7_akismet( $spam ) {
 	if ( $spam ) {
@@ -48,7 +48,20 @@ function wpcf7_akismet( $spam ) {
 		}
 	}
 
-	return wpcf7_akismet_comment_check( $c );
+	if ( wpcf7_akismet_comment_check( $c ) ) {
+		$spam = true;
+
+		$submission = WPCF7_Submission::get_instance();
+
+		$submission->add_spam_log( array(
+			'agent' => 'akismet',
+			'reason' => __( "Akismet returns a spam response.", 'contact-form-7' ),
+		) );
+	} else {
+		$spam = false;
+	}
+
+	return $spam;
 }
 
 function wpcf7_akismet_is_available() {
@@ -70,7 +83,8 @@ function wpcf7_akismet_submitted_params() {
 	$has_akismet_option = false;
 
 	foreach ( (array) $_POST as $key => $val ) {
-		if ( '_wpcf7' == substr( $key, 0, 6 ) || '_wpnonce' == $key ) {
+		if ( '_wpcf7' == substr( $key, 0, 6 )
+		or '_wpnonce' == $key ) {
 			continue;
 		}
 

--- a/wp-content/plugins/contact-form-7/modules/checkbox.php
+++ b/wp-content/plugins/contact-form-7/modules/checkbox.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_checkbox' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_checkbox', 10, 0 );
 
 function wpcf7_add_form_tag_checkbox() {
 	wpcf7_add_form_tag( array( 'checkbox', 'checkbox*', 'radio' ),
@@ -61,24 +61,24 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 	$html = '';
 	$count = 0;
 
-	$values = (array) $tag->values;
-	$labels = (array) $tag->labels;
-
 	if ( $data = (array) $tag->get_data_option() ) {
 		if ( $free_text ) {
-			$values = array_merge(
-				array_slice( $values, 0, -1 ),
+			$tag->values = array_merge(
+				array_slice( $tag->values, 0, -1 ),
 				array_values( $data ),
-				array_slice( $values, -1 ) );
-			$labels = array_merge(
-				array_slice( $labels, 0, -1 ),
+				array_slice( $tag->values, -1 ) );
+			$tag->labels = array_merge(
+				array_slice( $tag->labels, 0, -1 ),
 				array_values( $data ),
-				array_slice( $labels, -1 ) );
+				array_slice( $tag->labels, -1 ) );
 		} else {
-			$values = array_merge( $values, array_values( $data ) );
-			$labels = array_merge( $labels, array_values( $data ) );
+			$tag->values = array_merge( $tag->values, array_values( $data ) );
+			$tag->labels = array_merge( $tag->labels, array_values( $data ) );
 		}
 	}
+
+	$values = $tag->values;
+	$labels = $tag->labels;
 
 	$default_choice = $tag->get_default_option( null, array(
 		'multiple' => $multiple,
@@ -123,7 +123,8 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 			$item = '<label>' . $item . '</label>';
 		}
 
-		if ( false !== $tabindex && 0 < $tabindex ) {
+		if ( false !== $tabindex
+		and 0 < $tabindex ) {
 			$tabindex += 1;
 		}
 
@@ -147,7 +148,8 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 					'tabindex' => false !== $tabindex ? $tabindex : '',
 				);
 
-				if ( wpcf7_is_posted() && isset( $_POST[$free_text_name] ) ) {
+				if ( wpcf7_is_posted()
+				and isset( $_POST[$free_text_name] ) ) {
 					$free_text_atts['value'] = wp_unslash(
 						$_POST[$free_text_name] );
 				}
@@ -176,16 +178,19 @@ function wpcf7_checkbox_form_tag_handler( $tag ) {
 
 /* Validation filter */
 
-add_filter( 'wpcf7_validate_checkbox', 'wpcf7_checkbox_validation_filter', 10, 2 );
-add_filter( 'wpcf7_validate_checkbox*', 'wpcf7_checkbox_validation_filter', 10, 2 );
-add_filter( 'wpcf7_validate_radio', 'wpcf7_checkbox_validation_filter', 10, 2 );
+add_filter( 'wpcf7_validate_checkbox',
+	'wpcf7_checkbox_validation_filter', 10, 2 );
+add_filter( 'wpcf7_validate_checkbox*',
+	'wpcf7_checkbox_validation_filter', 10, 2 );
+add_filter( 'wpcf7_validate_radio',
+	'wpcf7_checkbox_validation_filter', 10, 2 );
 
 function wpcf7_checkbox_validation_filter( $result, $tag ) {
 	$name = $tag->name;
 	$is_required = $tag->is_required() || 'radio' == $tag->type;
 	$value = isset( $_POST[$name] ) ? (array) $_POST[$name] : array();
 
-	if ( $is_required && empty( $value ) ) {
+	if ( $is_required and empty( $value ) ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
 	}
 
@@ -195,7 +200,7 @@ function wpcf7_checkbox_validation_filter( $result, $tag ) {
 
 /* Adding free text field */
 
-add_filter( 'wpcf7_posted_data', 'wpcf7_checkbox_posted_data' );
+add_filter( 'wpcf7_posted_data', 'wpcf7_checkbox_posted_data', 10, 1 );
 
 function wpcf7_checkbox_posted_data( $posted_data ) {
 	$tags = wpcf7_scan_form_tags(
@@ -248,7 +253,7 @@ function wpcf7_checkbox_posted_data( $posted_data ) {
 /* Tag generator */
 
 add_action( 'wpcf7_admin_init',
-	'wpcf7_add_tag_generator_checkbox_and_radio', 30 );
+	'wpcf7_add_tag_generator_checkbox_and_radio', 30, 0 );
 
 function wpcf7_add_tag_generator_checkbox_and_radio() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/constant-contact.php
+++ b/wp-content/plugins/contact-form-7/modules/constant-contact.php
@@ -1,0 +1,943 @@
+<?php
+
+add_action( 'wpcf7_init', 'wpcf7_constant_contact_register_service', 10, 0 );
+
+function wpcf7_constant_contact_register_service() {
+	$integration = WPCF7_Integration::get_instance();
+
+	$integration->add_category( 'email_marketing',
+		__( 'Email Marketing', 'contact-form-7' ) );
+
+	$service = WPCF7_ConstantContact::get_instance();
+	$integration->add_service( 'constant_contact', $service );
+}
+
+add_action( 'wpcf7_save_contact_form',
+	'wpcf7_constant_contact_save_contact_form', 10, 1 );
+
+function wpcf7_constant_contact_save_contact_form( $contact_form ) {
+	$service = WPCF7_ConstantContact::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return;
+	}
+
+	$additional_settings = $contact_form->additional_setting(
+		'constant_contact',
+		false
+	);
+
+	$list_names = array();
+
+	$pattern = '/[\t ]*('
+		. "'[^']*'"
+		. '|'
+		. '"[^"]*"'
+		. '|'
+		. '[^,]*?'
+		. ')[\t ]*(?:[,]+|$)/';
+
+	foreach ( $additional_settings as $setting ) {
+		if ( preg_match_all( $pattern, $setting, $matches ) ) {
+			foreach ( $matches[1] as $match ) {
+				$name = trim( wpcf7_strip_quote( $match ) );
+
+				if ( '' !== $name ) {
+					$list_names[] = $name;
+				}
+			}
+		}
+	}
+
+	$list_names = array_unique( $list_names );
+
+	$key = sprintf( 'wpcf7_contact_form:%d', $contact_form->id() );
+
+	$service->update_contact_lists( array( $key => $list_names ) );
+}
+
+add_action( 'wpcf7_submit', 'wpcf7_constant_contact_submit', 10, 2 );
+
+function wpcf7_constant_contact_submit( $contact_form, $result ) {
+	$service = WPCF7_ConstantContact::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return;
+	}
+
+	if ( $contact_form->in_demo_mode() ) {
+		return;
+	}
+
+	$do_submit = true;
+
+	if ( empty( $result['status'] )
+	or ! in_array( $result['status'], array( 'mail_sent' ) ) ) {
+		$do_submit = false;
+	}
+
+	$additional_settings = $contact_form->additional_setting(
+		'constant_contact',
+		false
+	);
+
+	foreach ( $additional_settings as $setting ) {
+		if ( in_array( $setting, array( 'off', 'false', '0' ), true ) ) {
+			$do_submit = false;
+			break;
+		}
+	}
+
+	$do_submit = apply_filters( 'wpcf7_constant_contact_submit',
+		$do_submit, $contact_form, $result );
+
+	if ( ! $do_submit ) {
+		return;
+	}
+
+	$submission = WPCF7_Submission::get_instance();
+
+	$consented = true;
+
+	foreach ( $contact_form->scan_form_tags( 'feature=name-attr' ) as $tag ) {
+		if ( $tag->has_option( 'consent_for:constant_contact' )
+		and null == $submission->get_posted_data( $tag->name ) ) {
+			$consented = false;
+			break;
+		}
+	}
+
+	if ( ! $consented ) {
+		return;
+	}
+
+	$request_builder_class_name = apply_filters(
+		'wpcf7_constant_contact_contact_post_request_builder',
+		'WPCF7_ConstantContact_ContactPostRequest'
+	);
+
+	if ( ! class_exists( $request_builder_class_name ) ) {
+		return;
+	}
+
+	$request_builder = new $request_builder_class_name;
+	$request_builder->build( $submission );
+
+	if ( ! $request_builder->is_valid() ) {
+		return;
+	}
+
+	if ( $email = $request_builder->get_email_address()
+	and $service->email_exists( $email ) ) {
+		return;
+	}
+
+	$service->create_contact( $request_builder->to_array() );
+}
+
+if ( ! class_exists( 'WPCF7_Service_OAuth2' ) ) {
+	return;
+}
+
+class WPCF7_ConstantContact extends WPCF7_Service_OAuth2 {
+
+	const service_name = 'constant_contact';
+	const authorization_endpoint = 'https://api.cc.email/v3/idfed';
+	const token_endpoint = 'https://idfed.constantcontact.com/as/token.oauth2';
+
+	private static $instance;
+	protected $contact_lists = array();
+
+	public static function get_instance() {
+		if ( empty( self::$instance ) ) {
+			self::$instance = new self;
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
+		$this->authorization_endpoint = self::authorization_endpoint;
+		$this->token_endpoint = self::token_endpoint;
+
+		$option = (array) WPCF7::get_option( self::service_name );
+
+		if ( isset( $option['client_id'] ) ) {
+			$this->client_id = $option['client_id'];
+		}
+
+		if ( isset( $option['client_secret'] ) ) {
+			$this->client_secret = $option['client_secret'];
+		}
+
+		if ( isset( $option['access_token'] ) ) {
+			$this->access_token = $option['access_token'];
+		}
+
+		if ( isset( $option['refresh_token'] ) ) {
+			$this->refresh_token = $option['refresh_token'];
+		}
+
+		if ( $this->is_active() ) {
+			if ( isset( $option['contact_lists'] ) ) {
+				$this->contact_lists = $option['contact_lists'];
+			}
+		}
+
+		add_action( 'wpcf7_admin_init', array( $this, 'auth_redirect' ) );
+	}
+
+	public function auth_redirect() {
+		$auth = isset( $_GET['auth'] ) ? trim( $_GET['auth'] ) : '';
+		$code = isset( $_GET['code'] ) ? trim( $_GET['code'] ) : '';
+
+		if ( self::service_name === $auth and $code
+		and current_user_can( 'wpcf7_manage_integration' ) ) {
+			$redirect_to = add_query_arg(
+				array(
+					'service' => self::service_name,
+					'action' => 'auth_redirect',
+					'code' => $code,
+				),
+				menu_page_url( 'wpcf7-integration', false )
+			);
+
+			wp_safe_redirect( $redirect_to );
+			exit();
+		}
+	}
+
+	protected function save_data() {
+		$option = array_merge(
+			(array) WPCF7::get_option( self::service_name ),
+			array(
+				'client_id' => $this->client_id,
+				'client_secret' => $this->client_secret,
+				'access_token' => $this->access_token,
+				'refresh_token' => $this->refresh_token,
+				'contact_lists' => $this->contact_lists,
+			)
+		);
+
+		WPCF7::update_option( self::service_name, $option );
+	}
+
+	protected function reset_data() {
+		$this->client_id = '';
+		$this->client_secret = '';
+		$this->access_token = '';
+		$this->refresh_token = '';
+		$this->contact_lists = array();
+
+		$this->save_data();
+	}
+
+	public function get_title() {
+		return __( 'Constant Contact', 'contact-form-7' );
+	}
+
+	public function get_categories() {
+		return array( 'email_marketing' );
+	}
+
+	public function icon() {
+	}
+
+	public function link() {
+		echo sprintf( '<a href="%1$s">%2$s</a>',
+			'https://constant-contact.evyy.net/c/1293104/205991/3411',
+			'constantcontact.com'
+		);
+	}
+
+	protected function get_redirect_uri() {
+		return admin_url( '/?auth=' . self::service_name );
+	}
+
+	protected function menu_page_url( $args = '' ) {
+		$args = wp_parse_args( $args, array() );
+
+		$url = menu_page_url( 'wpcf7-integration', false );
+		$url = add_query_arg( array( 'service' => self::service_name ), $url );
+
+		if ( ! empty( $args) ) {
+			$url = add_query_arg( $args, $url );
+		}
+
+		return $url;
+	}
+
+	public function load( $action = '' ) {
+		parent::load( $action );
+
+		if ( 'setup' == $action and 'POST' == $_SERVER['REQUEST_METHOD'] ) {
+			check_admin_referer( 'wpcf7-constant-contact-setup' );
+
+			if ( ! empty( $_POST['reset'] ) ) {
+				$this->reset_data();
+			} else {
+				$this->client_id = isset( $_POST['client_id'] )
+					? trim( $_POST['client_id'] ) : '';
+
+				$this->client_secret = isset( $_POST['client_secret'] )
+					? trim( $_POST['client_secret'] ) : '';
+
+				$this->save_data();
+				$this->authorize( 'contact_data' );
+			}
+
+			wp_safe_redirect( $this->menu_page_url( 'action=setup' ) );
+			exit();
+		}
+
+		if ( 'edit' == $action and 'POST' == $_SERVER['REQUEST_METHOD'] ) {
+			check_admin_referer( 'wpcf7-constant-contact-edit' );
+
+			$list_ids = isset( $_POST['contact_lists'] )
+				? (array) $_POST['contact_lists']
+				: array();
+
+			$this->update_contact_lists( array( 'default' => $list_ids ) );
+
+			wp_safe_redirect( $this->menu_page_url(
+				array(
+					'action' => 'setup',
+					'message' => 'updated',
+				)
+			) );
+
+			exit();
+		}
+
+		if ( $this->is_active() ) {
+			$this->update_contact_lists();
+		}
+	}
+
+	public function email_exists( $email ) {
+		$endpoint = add_query_arg(
+			array( 'email' => $email ),
+			'https://api.cc.email/v3/contacts'
+		);
+
+		$request = array(
+			'method' => 'GET',
+			'headers' => array(
+				'Accept' => 'application/json',
+				'Content-Type' => 'application/json; charset=utf-8',
+			),
+		);
+
+		$response = $this->remote_request( $endpoint, $request );
+
+		if ( 400 <= (int) wp_remote_retrieve_response_code( $response ) ) {
+			if ( WP_DEBUG ) {
+				$this->log( $endpoint, $request, $response );
+			}
+
+			return false;
+		}
+
+		$response_body = wp_remote_retrieve_body( $response );
+
+		if ( empty( $response_body ) ) {
+			return false;
+		}
+
+		$response_body = json_decode( $response_body, true );
+
+		return ! empty( $response_body['contacts'] );
+	}
+
+	public function create_contact( $properties ) {
+		$endpoint = 'https://api.cc.email/v3/contacts';
+
+		$request = array(
+			'method' => 'POST',
+			'headers' => array(
+				'Accept' => 'application/json',
+				'Content-Type' => 'application/json; charset=utf-8',
+			),
+			'body' => json_encode( $properties ),
+		);
+
+		$response = $this->remote_request( $endpoint, $request );
+
+		if ( 400 <= (int) wp_remote_retrieve_response_code( $response ) ) {
+			if ( WP_DEBUG ) {
+				$this->log( $endpoint, $request, $response );
+			}
+
+			return false;
+		}
+	}
+
+	public function get_contact_lists() {
+		$endpoint = 'https://api.cc.email/v3/contact_lists';
+
+		$request = array(
+			'method' => 'GET',
+			'headers' => array(
+				'Accept' => 'application/json',
+				'Content-Type' => 'application/json; charset=utf-8',
+			),
+		);
+
+		$response = $this->remote_request( $endpoint, $request );
+
+		if ( 400 <= (int) wp_remote_retrieve_response_code( $response ) ) {
+			if ( WP_DEBUG ) {
+				$this->log( $endpoint, $request, $response );
+			}
+
+			return false;
+		}
+
+		$response_body = wp_remote_retrieve_body( $response );
+
+		if ( empty( $response_body ) ) {
+			return false;
+		}
+
+		$response_body = json_decode( $response_body, true );
+
+		if ( ! empty( $response_body['lists'] ) ) {
+			return (array) $response_body['lists'];
+		} else {
+			return array();
+		}
+	}
+
+	public function update_contact_lists( $selection = array() ) {
+		$contact_lists = array();
+		$contact_lists_on_api = $this->get_contact_lists();
+
+		if ( false !== $contact_lists_on_api ) {
+			foreach ( (array) $contact_lists_on_api as $list ) {
+				if ( isset( $list['list_id'] ) ) {
+					$list_id = trim( $list['list_id'] );
+				} else {
+					continue;
+				}
+
+				if ( isset( $this->contact_lists[$list_id]['selected'] ) ) {
+					$list['selected'] = $this->contact_lists[$list_id]['selected'];
+				} else {
+					$list['selected'] = array();
+				}
+
+				$contact_lists[$list_id] = $list;
+			}
+		} else {
+			$contact_lists = $this->contact_lists;
+		}
+
+		foreach ( (array) $selection as $key => $ids_or_names ) {
+			foreach( $contact_lists as $list_id => $list ) {
+				if ( in_array( $list['list_id'], (array) $ids_or_names, true )
+				or in_array( $list['name'], (array) $ids_or_names, true ) ) {
+					$contact_lists[$list_id]['selected'][$key] = true;
+				} else {
+					unset( $contact_lists[$list_id]['selected'][$key] );
+				}
+			}
+		}
+
+		$this->contact_lists = $contact_lists;
+
+		if ( $selection ) {
+			$this->save_data();
+		}
+
+		return $this->contact_lists;
+	}
+
+	public function admin_notice( $message = '' ) {
+		switch ( $message ) {
+			case 'success':
+				echo sprintf(
+					'<div class="updated notice notice-success is-dismissible"><p>%s</p></div>',
+					esc_html( __( "Connection established.", 'contact-form-7' ) )
+				);
+				break;
+			case 'failed':
+				echo sprintf(
+					'<div class="error notice notice-error is-dismissible"><p><strong>%1$s</strong>: %2$s</p></div>',
+					esc_html( __( "ERROR", 'contact-form-7' ) ),
+					esc_html( __( "Failed to establish connection. Please double-check your configuration.", 'contact-form-7' ) )
+				);
+				break;
+			case 'updated':
+				echo sprintf(
+					'<div class="updated notice notice-success is-dismissible"><p>%s</p></div>',
+					esc_html( __( "Configuration updated.", 'contact-form-7' ) )
+				);
+				break;
+		}
+	}
+
+	public function display( $action = '' ) {
+		echo '<p>' . sprintf(
+			esc_html( __( 'The Constant Contact integration module allows you to send contact data collected through your contact forms to the Constant Contact API. You can create reliable email subscription services in a few easy steps. For details, see %s.', 'contact-form-7' ) ),
+			wpcf7_link(
+				__(
+					'https://contactform7.com/constant-contact-integration/',
+					'contact-form-7'
+				),
+				__( 'Constant Contact Integration', 'contact-form-7' )
+			)
+		) . '</p>';
+
+		if ( $this->is_active() ) {
+			echo sprintf(
+				'<p class="dashicons-before dashicons-yes">%s</p>',
+				esc_html( __( "This site is connected to the Constant Contact API.", 'contact-form-7' ) )
+			);
+		}
+
+		if ( 'setup' == $action ) {
+			$this->display_setup();
+		} else {
+			echo sprintf(
+				'<p><a href="%1$s" class="button">%2$s</a></p>',
+				esc_url( $this->menu_page_url( 'action=setup' ) ),
+				esc_html( __( 'Setup Integration', 'contact-form-7' ) )
+			);
+		}
+	}
+
+	private function display_setup() {
+?>
+<form method="post" action="<?php echo esc_url( $this->menu_page_url( 'action=setup' ) ); ?>">
+<?php wp_nonce_field( 'wpcf7-constant-contact-setup' ); ?>
+<table class="form-table">
+<tbody>
+<tr>
+	<th scope="row"><label for="client_id"><?php echo esc_html( __( 'API Key', 'contact-form-7' ) ); ?></label></th>
+	<td><?php
+		if ( $this->is_active() ) {
+			echo esc_html( $this->client_id );
+			echo sprintf(
+				'<input type="hidden" value="%1$s" id="client_id" name="client_id" />',
+				esc_attr( $this->client_id )
+			);
+		} else {
+			echo sprintf(
+				'<input type="text" aria-required="true" value="%1$s" id="client_id" name="client_id" class="regular-text code" />',
+				esc_attr( $this->client_id )
+			);
+		}
+	?></td>
+</tr>
+<tr>
+	<th scope="row"><label for="client_secret"><?php echo esc_html( __( 'App Secret', 'contact-form-7' ) ); ?></label></th>
+	<td><?php
+		if ( $this->is_active() ) {
+			echo esc_html( wpcf7_mask_password( $this->client_secret ) );
+			echo sprintf(
+				'<input type="hidden" value="%1$s" id="client_secret" name="client_secret" />',
+				esc_attr( $this->client_secret )
+			);
+		} else {
+			echo sprintf(
+				'<input type="text" aria-required="true" value="%1$s" id="client_secret" name="client_secret" class="regular-text code" />',
+				esc_attr( $this->client_secret )
+			);
+		}
+	?></td>
+</tr>
+<tr>
+	<th scope="row"><label for="redirect_uri"><?php echo esc_html( __( 'Redirect URI', 'contact-form-7' ) ); ?></label></th>
+	<td><?php
+		echo sprintf(
+			'<input type="text" value="%1$s" id="redirect_uri" name="redirect_uri" class="large-text code" readonly="readonly" onfocus="this.select();" style="font-size: 11px;" />',
+			$this->get_redirect_uri()
+		);
+	?>
+	<p class="description"><?php echo esc_html( __( "Set this URL as the redirect URI.", 'contact-form-7' ) ); ?></p>
+	</td>
+</tr>
+</tbody>
+</table>
+<?php
+		if ( $this->is_active() ) {
+			submit_button(
+				_x( 'Reset Keys', 'API keys', 'contact-form-7' ),
+				'small', 'reset'
+			);
+		} else {
+			submit_button(
+				__( 'Connect to the Constant Contact API', 'contact-form-7' )
+			);
+		}
+?>
+</form>
+
+<?php
+		if ( $this->is_active() and ! empty( $this->contact_lists ) ) {
+?>
+<form method="post" action="<?php echo esc_url( $this->menu_page_url( 'action=edit' ) ); ?>">
+<?php wp_nonce_field( 'wpcf7-constant-contact-edit' ); ?>
+<table class="form-table">
+<tbody>
+<tr>
+	<th scope="row"><?php echo esc_html( _x( 'Contact Lists', 'Constant Contact', 'contact-form-7' ) ); ?></th>
+	<td>
+		<fieldset>
+		<legend class="screen-reader-text"><span><?php echo esc_html( _x( "Contact Lists: Select lists to which newly added contacts are to belong.", 'Constant Contact', 'contact-form-7' ) ); ?></span></legend>
+		<p class="description"><?php echo esc_html( __( "Select lists to which newly added contacts are to belong.", 'contact-form-7' ) ); ?></p>
+		<ul class="checkboxes"><?php
+			foreach ( $this->contact_lists as $list ) {
+				echo sprintf(
+					'<li><input %1$s /> <label for="%2$s">%3$s</label></li>',
+					wpcf7_format_atts( array(
+						'type' => 'checkbox',
+						'name' => 'contact_lists[]',
+						'value' => $list['list_id'],
+						'id' => 'contact_list_' . $list['list_id'],
+						'checked' => empty( $list['selected']['default'] )
+							? ''
+							: 'checked',
+					) ),
+					esc_attr( 'contact_list_' . $list['list_id'] ),
+					esc_html( $list['name'] )
+				);
+			}
+		?></ul>
+		</fieldset>
+	</td>
+</tr>
+</tbody>
+</table>
+<?php
+			submit_button();
+		}
+?>
+</form>
+<?php
+	}
+
+}
+
+class WPCF7_ConstantContact_ContactPostRequest {
+
+	private $email_address;
+	private $first_name;
+	private $last_name;
+	private $job_title;
+	private $company_name;
+	private $create_source;
+	private $birthday_month;
+	private $birthday_day;
+	private $anniversary;
+	private $custom_fields = array();
+	private $phone_numbers = array();
+	private $street_addresses = array();
+	private $list_memberships = array();
+
+	public function __construct() {
+	}
+
+	public function build( WPCF7_Submission $submission ) {
+		$this->set_create_source( 'Contact' );
+
+		$posted_data = (array) $submission->get_posted_data();
+
+		if ( isset( $posted_data['your-first-name'] ) ) {
+			$this->set_first_name( $posted_data['your-first-name'] );
+		}
+
+		if ( isset( $posted_data['your-last-name'] ) ) {
+			$this->set_last_name( $posted_data['your-last-name'] );
+		}
+
+		if ( ! ( $this->first_name || $this->last_name )
+		and isset( $posted_data['your-name'] ) ) {
+			$your_name = preg_split( '/[\s]+/', $posted_data['your-name'], 2 );
+			$this->set_first_name( array_shift( $your_name ) );
+			$this->set_last_name( array_shift( $your_name ) );
+		}
+
+		if ( isset( $posted_data['your-email'] ) ) {
+			$this->set_email_address( $posted_data['your-email'], 'implicit' );
+		}
+
+		if ( isset( $posted_data['your-job-title'] ) ) {
+			$this->set_job_title( $posted_data['your-job-title'] );
+		}
+
+		if ( isset( $posted_data['your-company-name'] ) ) {
+			$this->set_company_name( $posted_data['your-company-name'] );
+		}
+
+		if ( isset( $posted_data['your-birthday-month'] )
+		and isset( $posted_data['your-birthday-day'] ) ) {
+			$this->set_birthday(
+				$posted_data['your-birthday-month'],
+				$posted_data['your-birthday-day']
+			);
+		} elseif ( isset( $posted_data['your-birthday'] ) ) {
+			$date = trim( $posted_data['your-birthday'] );
+
+			if ( preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
+				$this->set_birthday( $matches[2], $matches[3] );
+			}
+		}
+
+		if ( isset( $posted_data['your-anniversary'] ) ) {
+			$this->set_anniversary( $posted_data['your-anniversary'] );
+		}
+
+		if ( isset( $posted_data['your-phone-number'] ) ) {
+			$this->add_phone_number( $posted_data['your-phone-number'] );
+		}
+
+		$this->add_street_address(
+			isset( $posted_data['your-address-street'] )
+				? $posted_data['your-address-street'] : '',
+			isset( $posted_data['your-address-city'] )
+				? $posted_data['your-address-city'] : '',
+			isset( $posted_data['your-address-state'] )
+				? $posted_data['your-address-state'] : '',
+			isset( $posted_data['your-address-postal-code'] )
+				? $posted_data['your-address-postal-code'] : '',
+			isset( $posted_data['your-address-country'] )
+				? $posted_data['your-address-country'] : ''
+		);
+
+		$service_option = (array) WPCF7::get_option( 'constant_contact' );
+
+		$contact_lists = isset( $service_option['contact_lists'] )
+			? $service_option['contact_lists'] : array();
+
+		$contact_form = $submission->get_contact_form();
+
+		if ( $contact_form->additional_setting( 'constant_contact' ) ) {
+			$key = sprintf( 'wpcf7_contact_form:%d', $contact_form->id() );
+		} else {
+			$key = 'default';
+		}
+
+		foreach ( (array) $contact_lists as $list ) {
+			if ( ! empty( $list['selected'][$key] ) ) {
+				$this->add_list_membership( $list['list_id'] );
+			}
+		}
+	}
+
+	public function is_valid() {
+		return $this->create_source
+			&& ( $this->email_address || $this->first_name || $this->last_name );
+	}
+
+	public function to_array() {
+		$output = array(
+			'email_address' => $this->email_address,
+			'first_name' => $this->first_name,
+			'last_name' => $this->last_name,
+			'job_title' => $this->job_title,
+			'company_name' => $this->company_name,
+			'create_source' => $this->create_source,
+			'birthday_month' => $this->birthday_month,
+			'birthday_day' => $this->birthday_day,
+			'anniversary' => $this->anniversary,
+			'custom_fields' => $this->custom_fields,
+			'phone_numbers' => $this->phone_numbers,
+			'street_addresses' => $this->street_addresses,
+			'list_memberships' => $this->list_memberships,
+		);
+
+		return array_filter( $output );
+	}
+
+	public function get_email_address() {
+		if ( isset( $this->email_address['address'] ) ) {
+			return $this->email_address['address'];
+		}
+
+		return '';
+	}
+
+	public function set_email_address( $address, $permission_to_send = '' ) {
+		if ( ! wpcf7_is_email( $address )
+		or 80 < $this->strlen( $address ) ) {
+			return false;
+		}
+
+		$types_of_permission = array(
+			'implicit', 'explicit', 'deprecate', 'pending',
+			'unsubscribe', 'temp_hold', 'not_set',
+		);
+
+		if ( ! in_array( $permission_to_send, $types_of_permission ) ) {
+			$permission_to_send = 'implicit';
+		}
+
+		return $this->email_address = array(
+			'address' => $address,
+			'permission_to_send' => $permission_to_send,
+		);
+	}
+
+	public function set_first_name( $first_name ) {
+		$first_name = trim( $first_name );
+
+		if ( empty( $first_name )
+		or 50 < $this->strlen( $first_name ) ) {
+			return false;
+		}
+
+		return $this->first_name = $first_name;
+	}
+
+	public function set_last_name( $last_name ) {
+		$last_name = trim( $last_name );
+
+		if ( empty( $last_name )
+		or 50 < $this->strlen( $last_name ) ) {
+			return false;
+		}
+
+		return $this->last_name = $last_name;
+	}
+
+	public function set_job_title( $job_title ) {
+		$job_title = trim( $job_title );
+
+		if ( empty( $job_title )
+		or 50 < $this->strlen( $job_title ) ) {
+			return false;
+		}
+
+		return $this->job_title = $job_title;
+	}
+
+	public function set_company_name( $company_name ) {
+		$company_name = trim( $company_name );
+
+		if ( empty( $company_name )
+		or 50 < $this->strlen( $company_name ) ) {
+			return false;
+		}
+
+		return $this->company_name = $company_name;
+	}
+
+	public function set_create_source( $create_source ) {
+		if ( ! in_array( $create_source, array( 'Contact', 'Account' ) ) ) {
+			return false;
+		}
+
+		return $this->create_source = $create_source;
+	}
+
+	public function set_birthday( $month, $day ) {
+		$month = (int) $month;
+		$day = (int) $day;
+
+		if ( $month < 1 || 12 < $month
+		or $day < 1 || 31 < $day ) {
+			return false;
+		}
+
+		$this->birthday_month = $month;
+		$this->birthday_day = $day;
+
+		return array( $this->birthday_month, $this->birthday_day );
+	}
+
+	public function set_anniversary( $anniversary ) {
+		$pattern = sprintf(
+			'#^(%s)$#',
+			implode( '|', array(
+				'\d{1,2}/\d{1,2}/\d{4}',
+				'\d{4}/\d{1,2}/\d{1,2}',
+				'\d{4}-\d{1,2}-\d{1,2}',
+				'\d{1,2}-\d{1,2}-\d{4}',
+			) )
+		);
+
+		if ( ! preg_match( $pattern, $anniversary ) ) {
+			return false;
+		}
+
+		return $this->anniversary = $anniversary;
+	}
+
+	public function add_custom_field( $custom_field_id, $value ) {
+		$uuid_pattern = '/^[0-9a-f-]+$/i';
+
+		$value = trim( $value );
+
+		if ( 25 <= count( $this->custom_fields )
+		or ! preg_match( $uuid_pattern, $custom_field_id )
+		or 255 < $this->strlen( $value ) ) {
+			return false;
+		}
+
+		return $this->custom_fields[] = array(
+			'custom_field_id' => $custom_field_id,
+			'value' => $value,
+		);
+	}
+
+	public function add_phone_number( $phone_number, $kind = 'home' ) {
+		$phone_number = trim( $phone_number );
+
+		if ( 2 <= count( $this->phone_numbers )
+		or ! wpcf7_is_tel( $phone_number )
+		or 25 < $this->strlen( $phone_number )
+		or ! in_array( $kind, array( 'home', 'work', 'other' ) ) ) {
+			return false;
+		}
+
+		return $this->phone_numbers[] = array(
+			'phone_number' => $phone_number,
+			'kind' => $kind,
+		);
+	}
+
+	public function add_street_address( $street, $city, $state, $postal_code, $country, $kind = 'home' ) {
+		$street = trim( $street );
+		$city = trim( $city );
+		$state = trim( $state );
+		$postal_code = trim( $postal_code );
+		$country = trim( $country );
+
+		if ( ! ( $street || $city || $state || $postal_code || $country )
+		or 1 <= count( $this->street_addresses )
+		or ! in_array( $kind, array( 'home', 'work', 'other' ) )
+		or 255 < $this->strlen( $street )
+		or 50 < $this->strlen( $city )
+		or 50 < $this->strlen( $state )
+		or 50 < $this->strlen( $postal_code )
+		or 50 < $this->strlen( $country ) ) {
+			return false;
+		}
+
+		return $this->street_addresses[] = array(
+			'kind' => $kind,
+			'street' => $street,
+			'city' => $city,
+			'state' => $state,
+			'postal_code' => $postal_code,
+			'country' => $country,
+		);
+	}
+
+	public function add_list_membership( $list_id ) {
+		$uuid_pattern = '/^[0-9a-f-]+$/i';
+
+		if ( 50 <= count( $this->list_memberships )
+		or ! preg_match( $uuid_pattern, $list_id ) ) {
+			return false;
+		}
+
+		return $this->list_memberships[] = $list_id;
+	}
+
+	protected function strlen( $string ) {
+		return wpcf7_count_code_units( stripslashes( $string ) );
+	}
+
+}

--- a/wp-content/plugins/contact-form-7/modules/count.php
+++ b/wp-content/plugins/contact-form-7/modules/count.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_count' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_count', 10, 0 );
 
 function wpcf7_add_form_tag_count() {
 	wpcf7_add_form_tag( 'count',
@@ -36,7 +36,8 @@ function wpcf7_count_form_tag_handler( $tag ) {
 		}
 	}
 
-	if ( $maxlength && $minlength && $maxlength < $minlength ) {
+	if ( $maxlength and $minlength
+	and $maxlength < $minlength ) {
 		$maxlength = $minlength = null;
 	}
 

--- a/wp-content/plugins/contact-form-7/modules/date.php
+++ b/wp-content/plugins/contact-form-7/modules/date.php
@@ -6,7 +6,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_date' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_date', 10, 0 );
 
 function wpcf7_add_form_tag_date() {
 	wpcf7_add_form_tag( array( 'date', 'date*' ),
@@ -49,7 +49,8 @@ function wpcf7_date_form_tag_handler( $tag ) {
 
 	$value = (string) reset( $tag->values );
 
-	if ( $tag->has_option( 'placeholder' ) || $tag->has_option( 'watermark' ) ) {
+	if ( $tag->has_option( 'placeholder' )
+	or $tag->has_option( 'watermark' ) ) {
 		$atts['placeholder'] = $value;
 		$value = '';
 	}
@@ -93,13 +94,13 @@ function wpcf7_date_validation_filter( $result, $tag ) {
 		? trim( strtr( (string) $_POST[$name], "\n", " " ) )
 		: '';
 
-	if ( $tag->is_required() && '' == $value ) {
+	if ( $tag->is_required() and '' == $value ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
-	} elseif ( '' != $value && ! wpcf7_is_date( $value ) ) {
+	} elseif ( '' != $value and ! wpcf7_is_date( $value ) ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_date' ) );
-	} elseif ( '' != $value && ! empty( $min ) && $value < $min ) {
+	} elseif ( '' != $value and ! empty( $min ) and $value < $min ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'date_too_early' ) );
-	} elseif ( '' != $value && ! empty( $max ) && $max < $value ) {
+	} elseif ( '' != $value and ! empty( $max ) and $max < $value ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'date_too_late' ) );
 	}
 
@@ -109,7 +110,7 @@ function wpcf7_date_validation_filter( $result, $tag ) {
 
 /* Messages */
 
-add_filter( 'wpcf7_messages', 'wpcf7_date_messages' );
+add_filter( 'wpcf7_messages', 'wpcf7_date_messages', 10, 1 );
 
 function wpcf7_date_messages( $messages ) {
 	return array_merge( $messages, array(
@@ -133,7 +134,7 @@ function wpcf7_date_messages( $messages ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_date', 19 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_date', 19, 0 );
 
 function wpcf7_add_tag_generator_date() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/file.php
+++ b/wp-content/plugins/contact-form-7/modules/file.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_file' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_file', 10, 0 );
 
 function wpcf7_add_form_tag_file() {
 	wpcf7_add_form_tag( array( 'file', 'file*' ),
@@ -56,7 +56,7 @@ function wpcf7_file_form_tag_handler( $tag ) {
 
 /* Encode type filter */
 
-add_filter( 'wpcf7_form_enctype', 'wpcf7_file_form_enctype_filter' );
+add_filter( 'wpcf7_form_enctype', 'wpcf7_file_form_enctype_filter', 10, 1 );
 
 function wpcf7_file_form_enctype_filter( $enctype ) {
 	$multipart = (bool) wpcf7_scan_form_tags(
@@ -81,12 +81,12 @@ function wpcf7_file_validation_filter( $result, $tag ) {
 
 	$file = isset( $_FILES[$name] ) ? $_FILES[$name] : null;
 
-	if ( $file['error'] && UPLOAD_ERR_NO_FILE != $file['error'] ) {
+	if ( $file['error'] and UPLOAD_ERR_NO_FILE != $file['error'] ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'upload_failed_php_error' ) );
 		return $result;
 	}
 
-	if ( empty( $file['tmp_name'] ) && $tag->is_required() ) {
+	if ( empty( $file['tmp_name'] ) and $tag->is_required() ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
 		return $result;
 	}
@@ -110,31 +110,9 @@ function wpcf7_file_validation_filter( $result, $tag ) {
 
 	/* File size validation */
 
-	$allowed_size = 1048576; // default size 1 MB
+	$allowed_size = $tag->get_limit_option();
 
-	if ( $file_size_a = $tag->get_option( 'limit' ) ) {
-		$limit_pattern = '/^([1-9][0-9]*)([kKmM]?[bB])?$/';
-
-		foreach ( $file_size_a as $file_size ) {
-			if ( preg_match( $limit_pattern, $file_size, $matches ) ) {
-				$allowed_size = (int) $matches[1];
-
-				if ( ! empty( $matches[2] ) ) {
-					$kbmb = strtolower( $matches[2] );
-
-					if ( 'kb' == $kbmb ) {
-						$allowed_size *= 1024;
-					} elseif ( 'mb' == $kbmb ) {
-						$allowed_size *= 1024 * 1024;
-					}
-				}
-
-				break;
-			}
-		}
-	}
-
-	if ( $file['size'] > $allowed_size ) {
+	if ( $allowed_size < $file['size'] ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'upload_file_too_large' ) );
 		return $result;
 	}
@@ -153,7 +131,7 @@ function wpcf7_file_validation_filter( $result, $tag ) {
 	$filename = wp_unique_filename( $uploads_dir, $filename );
 	$new_file = path_join( $uploads_dir, $filename );
 
-	if ( false === move_uploaded_file( $file['tmp_name'], $new_file ) ) {
+	if ( false === @move_uploaded_file( $file['tmp_name'], $new_file ) ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'upload_failed' ) );
 		return $result;
 	}
@@ -171,7 +149,7 @@ function wpcf7_file_validation_filter( $result, $tag ) {
 
 /* Messages */
 
-add_filter( 'wpcf7_messages', 'wpcf7_file_messages' );
+add_filter( 'wpcf7_messages', 'wpcf7_file_messages', 10, 1 );
 
 function wpcf7_file_messages( $messages ) {
 	return array_merge( $messages, array(
@@ -200,7 +178,7 @@ function wpcf7_file_messages( $messages ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_file', 50 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_file', 50, 0 );
 
 function wpcf7_add_tag_generator_file() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();
@@ -280,10 +258,13 @@ function wpcf7_tag_generator_file( $contact_form, $args = '' ) {
 
 /* Warning message */
 
-add_action( 'wpcf7_admin_warnings', 'wpcf7_file_display_warning_message' );
+add_action( 'wpcf7_admin_warnings',
+	'wpcf7_file_display_warning_message', 10, 3 );
 
-function wpcf7_file_display_warning_message() {
-	if ( ! $contact_form = wpcf7_get_current_contact_form() ) {
+function wpcf7_file_display_warning_message( $page, $action, $object ) {
+	if ( $object instanceof WPCF7_ContactForm ) {
+		$contact_form = $object;
+	} else {
 		return;
 	}
 
@@ -297,7 +278,8 @@ function wpcf7_file_display_warning_message() {
 	$uploads_dir = wpcf7_upload_tmp_dir();
 	wpcf7_init_uploads();
 
-	if ( ! is_dir( $uploads_dir ) || ! wp_is_writable( $uploads_dir ) ) {
+	if ( ! is_dir( $uploads_dir )
+	or ! wp_is_writable( $uploads_dir ) ) {
 		$message = sprintf( __( 'This contact form contains file uploading fields, but the temporary folder for the files (%s) does not exist or is not writable. You can create the folder or change its permission manually.', 'contact-form-7' ), $uploads_dir );
 
 		echo sprintf( '<div class="notice notice-warning"><p>%s</p></div>',
@@ -309,7 +291,8 @@ function wpcf7_file_display_warning_message() {
 /* File uploading functions */
 
 function wpcf7_acceptable_filetypes( $types = 'default', $format = 'regex' ) {
-	if ( 'default' === $types || empty( $types ) ) {
+	if ( 'default' === $types
+	or empty( $types ) ) {
 		$types = array(
 			'jpg',
 			'jpeg',
@@ -359,7 +342,8 @@ function wpcf7_acceptable_filetypes( $types = 'default', $format = 'regex' ) {
 			continue;
 		}
 
-		if ( 'attr' === $format || 'attribute' === $format ) {
+		if ( 'attr' === $format
+		or 'attribute' === $format ) {
 			$output .= sprintf( '.%s', $type );
 			$output .= ',';
 		} else {
@@ -412,14 +396,19 @@ function wpcf7_upload_tmp_dir() {
 add_action( 'template_redirect', 'wpcf7_cleanup_upload_files', 20, 0 );
 
 function wpcf7_cleanup_upload_files( $seconds = 60, $max = 100 ) {
-	if ( is_admin() || 'GET' != $_SERVER['REQUEST_METHOD']
-	|| is_robots() || is_feed() || is_trackback() ) {
+	if ( is_admin()
+	or 'GET' != $_SERVER['REQUEST_METHOD']
+	or is_robots()
+	or is_feed()
+	or is_trackback() ) {
 		return;
 	}
 
 	$dir = trailingslashit( wpcf7_upload_tmp_dir() );
 
-	if ( ! is_dir( $dir ) || ! is_readable( $dir ) || ! wp_is_writable( $dir ) ) {
+	if ( ! is_dir( $dir )
+	or ! is_readable( $dir )
+	or ! wp_is_writable( $dir ) ) {
 		return;
 	}
 
@@ -429,13 +418,15 @@ function wpcf7_cleanup_upload_files( $seconds = 60, $max = 100 ) {
 
 	if ( $handle = opendir( $dir ) ) {
 		while ( false !== ( $file = readdir( $handle ) ) ) {
-			if ( '.' == $file || '..' == $file || '.htaccess' == $file ) {
+			if ( '.' == $file
+			or '..' == $file
+			or '.htaccess' == $file ) {
 				continue;
 			}
 
-			$mtime = filemtime( path_join( $dir, $file ) );
+			$mtime = @filemtime( path_join( $dir, $file ) );
 
-			if ( $mtime && time() < $mtime + $seconds ) { // less than $seconds old
+			if ( $mtime and time() < $mtime + $seconds ) { // less than $seconds old
 				continue;
 			}
 

--- a/wp-content/plugins/contact-form-7/modules/flamingo.php
+++ b/wp-content/plugins/contact-form-7/modules/flamingo.php
@@ -8,7 +8,7 @@ add_action( 'wpcf7_submit', 'wpcf7_flamingo_submit', 10, 2 );
 
 function wpcf7_flamingo_submit( $contact_form, $result ) {
 	if ( ! class_exists( 'Flamingo_Contact' )
-	|| ! class_exists( 'Flamingo_Inbound_Message' ) ) {
+	or ! class_exists( 'Flamingo_Inbound_Message' ) ) {
 		return;
 	}
 
@@ -20,13 +20,14 @@ function wpcf7_flamingo_submit( $contact_form, $result ) {
 		array( 'spam', 'mail_sent', 'mail_failed' ) );
 
 	if ( empty( $result['status'] )
-	|| ! in_array( $result['status'], $cases ) ) {
+	or ! in_array( $result['status'], $cases ) ) {
 		return;
 	}
 
 	$submission = WPCF7_Submission::get_instance();
 
-	if ( ! $submission || ! $posted_data = $submission->get_posted_data() ) {
+	if ( ! $submission
+	or ! $posted_data = $submission->get_posted_data() ) {
 		return;
 	}
 
@@ -46,7 +47,8 @@ function wpcf7_flamingo_submit( $contact_form, $result ) {
 	$exclude_names[] = 'g-recaptcha-response';
 
 	foreach ( $posted_data as $key => $value ) {
-		if ( '_' == substr( $key, 0, 1 ) || in_array( $key, $exclude_names ) ) {
+		if ( '_' == substr( $key, 0, 1 )
+		or in_array( $key, $exclude_names ) ) {
 			unset( $posted_data[$key] );
 		}
 	}
@@ -87,7 +89,7 @@ function wpcf7_flamingo_submit( $contact_form, $result ) {
 
 	if ( $channel_id ) {
 		if ( ! isset( $post_meta['channel'] )
-		|| $post_meta['channel'] !== $channel_id ) {
+		or $post_meta['channel'] !== $channel_id ) {
 			$post_meta = empty( $post_meta ) ? array() : (array) $post_meta;
 			$post_meta = array_merge( $post_meta, array(
 				'channel' => $channel_id,
@@ -99,7 +101,7 @@ function wpcf7_flamingo_submit( $contact_form, $result ) {
 		$channel = get_term( $channel_id,
 			Flamingo_Inbound_Message::channel_taxonomy );
 
-		if ( ! $channel || is_wp_error( $channel ) ) {
+		if ( ! $channel or is_wp_error( $channel ) ) {
 			$channel = 'contact-form-7';
 		} else {
 			$channel = $channel->slug;
@@ -121,6 +123,14 @@ function wpcf7_flamingo_submit( $contact_form, $result ) {
 		'consent' => $submission->collect_consent(),
 	);
 
+	if ( $args['spam'] ) {
+		$args['spam_log'] = $submission->get_spam_log();
+	}
+
+	if ( isset( $submission->recaptcha ) ) {
+		$args['recaptcha'] = $submission->recaptcha;
+	}
+
 	$flamingo_inbound = Flamingo_Inbound_Message::add( $args );
 
 	$result += array(
@@ -134,7 +144,8 @@ function wpcf7_flamingo_submit( $contact_form, $result ) {
 }
 
 function wpcf7_flamingo_get_value( $field, $contact_form ) {
-	if ( empty( $field ) || empty( $contact_form ) ) {
+	if ( empty( $field )
+	or empty( $contact_form ) ) {
 		return false;
 	}
 
@@ -204,7 +215,7 @@ function wpcf7_flamingo_add_channel( $slug, $name = '' ) {
 	return (int) $channel['term_id'];
 }
 
-add_action( 'wpcf7_after_update', 'wpcf7_flamingo_update_channel' );
+add_action( 'wpcf7_after_update', 'wpcf7_flamingo_update_channel', 10, 1 );
 
 function wpcf7_flamingo_update_channel( $contact_form ) {
 	if ( ! class_exists( 'Flamingo_Inbound_Message' ) ) {
@@ -219,7 +230,7 @@ function wpcf7_flamingo_update_channel( $contact_form ) {
 		: get_term_by( 'slug', $contact_form->name(),
 			Flamingo_Inbound_Message::channel_taxonomy );
 
-	if ( ! $channel || is_wp_error( $channel ) ) {
+	if ( ! $channel or is_wp_error( $channel ) ) {
 		return;
 	}
 
@@ -243,7 +254,7 @@ function wpcf7_flamingo_serial_number( $output, $name, $html ) {
 	}
 
 	if ( ! class_exists( 'Flamingo_Inbound_Message' )
-	|| ! method_exists( 'Flamingo_Inbound_Message', 'count' ) ) {
+	or ! method_exists( 'Flamingo_Inbound_Message', 'count' ) ) {
 		return $output;
 	}
 

--- a/wp-content/plugins/contact-form-7/modules/hidden.php
+++ b/wp-content/plugins/contact-form-7/modules/hidden.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_hidden' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_hidden', 10, 0 );
 
 function wpcf7_add_form_tag_hidden() {
 	wpcf7_add_form_tag( 'hidden',

--- a/wp-content/plugins/contact-form-7/modules/number.php
+++ b/wp-content/plugins/contact-form-7/modules/number.php
@@ -7,7 +7,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_number' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_number', 10, 0 );
 
 function wpcf7_add_form_tag_number() {
 	wpcf7_add_form_tag( array( 'number', 'number*', 'range', 'range*' ),
@@ -50,7 +50,8 @@ function wpcf7_number_form_tag_handler( $tag ) {
 
 	$value = (string) reset( $tag->values );
 
-	if ( $tag->has_option( 'placeholder' ) || $tag->has_option( 'watermark' ) ) {
+	if ( $tag->has_option( 'placeholder' )
+	or $tag->has_option( 'watermark' ) ) {
 		$atts['placeholder'] = $value;
 		$value = '';
 	}
@@ -96,13 +97,13 @@ function wpcf7_number_validation_filter( $result, $tag ) {
 	$min = $tag->get_option( 'min', 'signed_int', true );
 	$max = $tag->get_option( 'max', 'signed_int', true );
 
-	if ( $tag->is_required() && '' == $value ) {
+	if ( $tag->is_required() and '' == $value ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
-	} elseif ( '' != $value && ! wpcf7_is_number( $value ) ) {
+	} elseif ( '' != $value and ! wpcf7_is_number( $value ) ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_number' ) );
-	} elseif ( '' != $value && '' != $min && (float) $value < (float) $min ) {
+	} elseif ( '' != $value and '' != $min and (float) $value < (float) $min ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'number_too_small' ) );
-	} elseif ( '' != $value && '' != $max && (float) $max < (float) $value ) {
+	} elseif ( '' != $value and '' != $max and (float) $max < (float) $value ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'number_too_large' ) );
 	}
 
@@ -112,7 +113,7 @@ function wpcf7_number_validation_filter( $result, $tag ) {
 
 /* Messages */
 
-add_filter( 'wpcf7_messages', 'wpcf7_number_messages' );
+add_filter( 'wpcf7_messages', 'wpcf7_number_messages', 10, 1 );
 
 function wpcf7_number_messages( $messages ) {
 	return array_merge( $messages, array(
@@ -136,7 +137,7 @@ function wpcf7_number_messages( $messages ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_number', 18 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_number', 18, 0 );
 
 function wpcf7_add_tag_generator_number() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/quiz.php
+++ b/wp-content/plugins/contact-form-7/modules/quiz.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_quiz' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_quiz', 10, 0 );
 
 function wpcf7_add_form_tag_quiz() {
 	wpcf7_add_form_tag( 'quiz',
@@ -37,7 +37,8 @@ function wpcf7_quiz_form_tag_handler( $tag ) {
 	$atts['maxlength'] = $tag->get_maxlength_option();
 	$atts['minlength'] = $tag->get_minlength_option();
 
-	if ( $atts['maxlength'] && $atts['minlength'] && $atts['maxlength'] < $atts['minlength'] ) {
+	if ( $atts['maxlength'] and $atts['minlength']
+	and $atts['maxlength'] < $atts['minlength'] ) {
 		unset( $atts['maxlength'], $atts['minlength'] );
 	}
 
@@ -50,7 +51,8 @@ function wpcf7_quiz_form_tag_handler( $tag ) {
 
 	$pipes = $tag->pipes;
 
-	if ( $pipes instanceof WPCF7_Pipes && ! $pipes->zero() ) {
+	if ( $pipes instanceof WPCF7_Pipes
+	and ! $pipes->zero() ) {
 		$pipe = $pipes->random_pipe();
 		$question = $pipe->before;
 		$answer = $pipe->after;
@@ -103,8 +105,8 @@ function wpcf7_quiz_validation_filter( $result, $tag ) {
 
 /* Ajax echo filter */
 
-add_filter( 'wpcf7_ajax_onload', 'wpcf7_quiz_ajax_refill' );
-add_filter( 'wpcf7_ajax_json_echo', 'wpcf7_quiz_ajax_refill' );
+add_filter( 'wpcf7_ajax_onload', 'wpcf7_quiz_ajax_refill', 10, 1 );
+add_filter( 'wpcf7_ajax_json_echo', 'wpcf7_quiz_ajax_refill', 10, 1 );
 
 function wpcf7_quiz_ajax_refill( $items ) {
 	if ( ! is_array( $items ) ) {
@@ -127,7 +129,8 @@ function wpcf7_quiz_ajax_refill( $items ) {
 			continue;
 		}
 
-		if ( $pipes instanceof WPCF7_Pipes && ! $pipes->zero() ) {
+		if ( $pipes instanceof WPCF7_Pipes
+		and ! $pipes->zero() ) {
 			$pipe = $pipes->random_pipe();
 			$question = $pipe->before;
 			$answer = $pipe->after;
@@ -152,7 +155,7 @@ function wpcf7_quiz_ajax_refill( $items ) {
 
 /* Messages */
 
-add_filter( 'wpcf7_messages', 'wpcf7_quiz_messages' );
+add_filter( 'wpcf7_messages', 'wpcf7_quiz_messages', 10, 1 );
 
 function wpcf7_quiz_messages( $messages ) {
 	$messages = array_merge( $messages, array(
@@ -170,7 +173,7 @@ function wpcf7_quiz_messages( $messages ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_quiz', 40 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_quiz', 40, 0 );
 
 function wpcf7_add_tag_generator_quiz() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/really-simple-captcha.php
+++ b/wp-content/plugins/contact-form-7/modules/really-simple-captcha.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_captcha' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_captcha', 10, 0 );
 
 function wpcf7_add_form_tag_captcha() {
 	// CAPTCHA-Challenge (image)
@@ -34,7 +34,8 @@ function wpcf7_captchac_form_tag_handler( $tag ) {
 		$error = sprintf(
 			/* translators: %s: link labeled 'Really Simple CAPTCHA' */
 			esc_html( __( "To use CAPTCHA, you need %s plugin installed.", 'contact-form-7' ) ),
-			wpcf7_link( 'https://wordpress.org/plugins/really-simple-captcha/', 'Really Simple CAPTCHA' ) );
+			wpcf7_link( 'https://wordpress.org/plugins/really-simple-captcha/', 'Really Simple CAPTCHA' )
+		);
 
 		return sprintf( '<em>%s</em>', $error );
 	}
@@ -106,8 +107,8 @@ function wpcf7_captchar_form_tag_handler( $tag ) {
 	$atts['maxlength'] = $tag->get_maxlength_option();
 	$atts['minlength'] = $tag->get_minlength_option();
 
-	if ( $atts['maxlength'] && $atts['minlength']
-	&& $atts['maxlength'] < $atts['minlength'] ) {
+	if ( $atts['maxlength'] and $atts['minlength']
+	and $atts['maxlength'] < $atts['minlength'] ) {
 		unset( $atts['maxlength'], $atts['minlength'] );
 	}
 
@@ -124,7 +125,7 @@ function wpcf7_captchar_form_tag_handler( $tag ) {
 	}
 
 	if ( $tag->has_option( 'placeholder' )
-	|| $tag->has_option( 'watermark' ) ) {
+	or $tag->has_option( 'watermark' ) ) {
 		$atts['placeholder'] = $value;
 		$value = '';
 	}
@@ -145,7 +146,8 @@ function wpcf7_captchar_form_tag_handler( $tag ) {
 
 /* Validation filter */
 
-add_filter( 'wpcf7_validate_captchar', 'wpcf7_captcha_validation_filter', 10, 2 );
+add_filter( 'wpcf7_validate_captchar',
+	'wpcf7_captcha_validation_filter', 10, 2 );
 
 function wpcf7_captcha_validation_filter( $result, $tag ) {
 	$type = $tag->type;
@@ -157,7 +159,8 @@ function wpcf7_captcha_validation_filter( $result, $tag ) {
 	$response = isset( $_POST[$name] ) ? (string) $_POST[$name] : '';
 	$response = wpcf7_canonicalize( $response );
 
-	if ( 0 == strlen( $prefix ) || ! wpcf7_check_captcha( $prefix, $response ) ) {
+	if ( 0 == strlen( $prefix )
+	or ! wpcf7_check_captcha( $prefix, $response ) ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'captcha_not_match' ) );
 	}
 
@@ -171,8 +174,8 @@ function wpcf7_captcha_validation_filter( $result, $tag ) {
 
 /* Ajax echo filter */
 
-add_filter( 'wpcf7_ajax_onload', 'wpcf7_captcha_ajax_refill' );
-add_filter( 'wpcf7_ajax_json_echo', 'wpcf7_captcha_ajax_refill' );
+add_filter( 'wpcf7_ajax_onload', 'wpcf7_captcha_ajax_refill', 10, 1 );
+add_filter( 'wpcf7_ajax_json_echo', 'wpcf7_captcha_ajax_refill', 10, 1 );
 
 function wpcf7_captcha_ajax_refill( $items ) {
 	if ( ! is_array( $items ) ) {
@@ -213,7 +216,7 @@ function wpcf7_captcha_ajax_refill( $items ) {
 
 /* Messages */
 
-add_filter( 'wpcf7_messages', 'wpcf7_captcha_messages' );
+add_filter( 'wpcf7_messages', 'wpcf7_captcha_messages', 10, 1 );
 
 function wpcf7_captcha_messages( $messages ) {
 	$messages = array_merge( $messages, array(
@@ -231,7 +234,7 @@ function wpcf7_captcha_messages( $messages ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_captcha', 46 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_captcha', 46, 0 );
 
 function wpcf7_add_tag_generator_captcha() {
 	if ( ! wpcf7_use_really_simple_captcha() ) {
@@ -328,10 +331,13 @@ function wpcf7_tag_generator_captcha( $contact_form, $args = '' ) {
 
 /* Warning message */
 
-add_action( 'wpcf7_admin_warnings', 'wpcf7_captcha_display_warning_message' );
+add_action( 'wpcf7_admin_warnings',
+	'wpcf7_captcha_display_warning_message', 10, 3 );
 
-function wpcf7_captcha_display_warning_message() {
-	if ( ! $contact_form = wpcf7_get_current_contact_form() ) {
+function wpcf7_captcha_display_warning_message( $page, $action, $object ) {
+	if ( $object instanceof WPCF7_ContactForm ) {
+		$contact_form = $object;
+	} else {
 		return;
 	}
 
@@ -349,14 +355,15 @@ function wpcf7_captcha_display_warning_message() {
 	$uploads_dir = wpcf7_captcha_tmp_dir();
 	wpcf7_init_captcha();
 
-	if ( ! is_dir( $uploads_dir ) || ! wp_is_writable( $uploads_dir ) ) {
+	if ( ! is_dir( $uploads_dir )
+	or ! wp_is_writable( $uploads_dir ) ) {
 		$message = sprintf( __( 'This contact form contains CAPTCHA fields, but the temporary folder for the files (%s) does not exist or is not writable. You can create the folder or change its permission manually.', 'contact-form-7' ), $uploads_dir );
 
 		echo '<div class="notice notice-warning"><p>' . esc_html( $message ) . '</p></div>';
 	}
 
 	if ( ! function_exists( 'imagecreatetruecolor' )
-	|| ! function_exists( 'imagettftext' ) ) {
+	or ! function_exists( 'imagettftext' ) ) {
 		$message = __( "This contact form contains CAPTCHA fields, but the necessary libraries (GD and FreeType) are not available on your server.", 'contact-form-7' );
 
 		echo '<div class="notice notice-warning"><p>' . esc_html( $message ) . '</p></div>';
@@ -434,7 +441,8 @@ function wpcf7_captcha_tmp_url() {
 function wpcf7_captcha_url( $filename ) {
 	$url = path_join( wpcf7_captcha_tmp_url(), $filename );
 
-	if ( is_ssl() && 'http:' == substr( $url, 0, 5 ) ) {
+	if ( is_ssl()
+	and 'http:' == substr( $url, 0, 5 ) ) {
 		$url = 'https:' . substr( $url, 5 );
 	}
 
@@ -447,7 +455,7 @@ function wpcf7_generate_captcha( $options = null ) {
 	}
 
 	if ( ! is_dir( $captcha->tmp_dir )
-	|| ! wp_is_writable( $captcha->tmp_dir ) ) {
+	or ! wp_is_writable( $captcha->tmp_dir ) ) {
 		return false;
 	}
 
@@ -515,7 +523,7 @@ function wpcf7_remove_captcha( $prefix ) {
 	$captcha->remove( $prefix );
 }
 
-add_action( 'template_redirect', 'wpcf7_cleanup_captcha_files', 20 );
+add_action( 'template_redirect', 'wpcf7_cleanup_captcha_files', 20, 0 );
 
 function wpcf7_cleanup_captcha_files() {
 	if ( ! $captcha = wpcf7_init_captcha() ) {
@@ -528,7 +536,9 @@ function wpcf7_cleanup_captcha_files() {
 
 	$dir = trailingslashit( wpcf7_captcha_tmp_dir() );
 
-	if ( ! is_dir( $dir ) || ! is_readable( $dir ) || ! wp_is_writable( $dir ) ) {
+	if ( ! is_dir( $dir )
+	or ! is_readable( $dir )
+	or ! wp_is_writable( $dir ) ) {
 		return false;
 	}
 
@@ -541,7 +551,7 @@ function wpcf7_cleanup_captcha_files() {
 			$stat = stat( path_join( $dir, $file ) );
 
 			if ( $stat['mtime'] + 3600 < time() ) { // 3600 secs == 1 hour
-				unlink( path_join( $dir, $file ) );
+				@unlink( path_join( $dir, $file ) );
 			}
 		}
 

--- a/wp-content/plugins/contact-form-7/modules/recaptcha.php
+++ b/wp-content/plugins/contact-form-7/modules/recaptcha.php
@@ -1,11 +1,255 @@
 <?php
 
-class WPCF7_RECAPTCHA extends WPCF7_Service {
+add_action( 'wpcf7_init', 'wpcf7_recaptcha_register_service', 10, 0 );
 
-	const VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+function wpcf7_recaptcha_register_service() {
+	$integration = WPCF7_Integration::get_instance();
+
+	$integration->add_category( 'captcha',
+		__( 'CAPTCHA', 'contact-form-7' )
+	);
+
+	$integration->add_service( 'recaptcha',
+		WPCF7_RECAPTCHA::get_instance()
+	);
+}
+
+add_action( 'wp_enqueue_scripts', 'wpcf7_recaptcha_enqueue_scripts', 10, 0 );
+
+function wpcf7_recaptcha_enqueue_scripts() {
+	$service = WPCF7_RECAPTCHA::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return;
+	}
+
+	$url = add_query_arg(
+		array(
+			'render' => $service->get_sitekey(),
+		),
+		'https://www.google.com/recaptcha/api.js'
+	);
+
+	wp_enqueue_script( 'google-recaptcha', $url, array(), '3.0', true );
+}
+
+add_filter( 'wpcf7_form_hidden_fields',
+	'wpcf7_recaptcha_add_hidden_fields', 100, 1 );
+
+function wpcf7_recaptcha_add_hidden_fields( $fields ) {
+	$service = WPCF7_RECAPTCHA::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return $fields;
+	}
+
+	return array_merge( $fields, array(
+		'g-recaptcha-response' => '',
+	) );
+}
+
+add_action( 'wp_footer', 'wpcf7_recaptcha_onload_script', 40, 0 );
+
+function wpcf7_recaptcha_onload_script() {
+	$service = WPCF7_RECAPTCHA::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return;
+	}
+
+	if ( ! wp_script_is( 'google-recaptcha', 'done' ) ) {
+		return;
+	}
+
+	$actions = apply_filters( 'wpcf7_recaptcha_actions',
+		array(
+			'homepage' => 'homepage',
+			'contactform' => 'contactform',
+		)
+	);
+
+?>
+<script type="text/javascript">
+( function( grecaptcha, sitekey, actions ) {
+
+	var wpcf7recaptcha = {
+
+		execute: function( action ) {
+			grecaptcha.execute(
+				sitekey,
+				{ action: action }
+			).then( function( token ) {
+				var forms = document.getElementsByTagName( 'form' );
+
+				for ( var i = 0; i < forms.length; i++ ) {
+					var fields = forms[ i ].getElementsByTagName( 'input' );
+
+					for ( var j = 0; j < fields.length; j++ ) {
+						var field = fields[ j ];
+
+						if ( 'g-recaptcha-response' === field.getAttribute( 'name' ) ) {
+							field.setAttribute( 'value', token );
+							break;
+						}
+					}
+				}
+			} );
+		},
+
+		executeOnHomepage: function() {
+			wpcf7recaptcha.execute( actions[ 'homepage' ] );
+		},
+
+		executeOnContactform: function() {
+			wpcf7recaptcha.execute( actions[ 'contactform' ] );
+		},
+
+	};
+
+	grecaptcha.ready(
+		wpcf7recaptcha.executeOnHomepage
+	);
+
+	document.addEventListener( 'change',
+		wpcf7recaptcha.executeOnContactform, false
+	);
+
+	document.addEventListener( 'wpcf7submit',
+		wpcf7recaptcha.executeOnHomepage, false
+	);
+
+} )(
+	grecaptcha,
+	'<?php echo esc_js( $service->get_sitekey() ); ?>',
+	<?php echo json_encode( $actions ), "\n"; ?>
+);
+</script>
+<?php
+}
+
+add_filter( 'wpcf7_spam', 'wpcf7_recaptcha_verify_response', 9, 1 );
+
+function wpcf7_recaptcha_verify_response( $spam ) {
+	if ( $spam ) {
+		return $spam;
+	}
+
+	$service = WPCF7_RECAPTCHA::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return $spam;
+	}
+
+	$submission = WPCF7_Submission::get_instance();
+
+	$token = isset( $_POST['g-recaptcha-response'] )
+		? trim( $_POST['g-recaptcha-response'] ) : '';
+
+	if ( $service->verify( $token ) ) { // Human
+		$spam = false;
+	} else { // Bot
+		$spam = true;
+
+		if ( '' === $token ) {
+			$submission->add_spam_log( array(
+				'agent' => 'recaptcha',
+				'reason' => __( 'reCAPTCHA response token is empty.', 'contact-form-7' ),
+			) );
+		} else {
+			$submission->add_spam_log( array(
+				'agent' => 'recaptcha',
+				'reason' => sprintf(
+					__( 'reCAPTCHA score (%1$.2f) is lower than the threshold (%2$.2f).', 'contact-form-7' ),
+					$service->get_last_score(),
+					$service->get_threshold()
+				),
+			) );
+		}
+	}
+
+	return $spam;
+}
+
+add_action( 'wpcf7_init', 'wpcf7_recaptcha_add_form_tag_recaptcha', 10, 0 );
+
+function wpcf7_recaptcha_add_form_tag_recaptcha() {
+	$service = WPCF7_RECAPTCHA::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return;
+	}
+
+	wpcf7_add_form_tag( 'recaptcha',
+		'__return_empty_string', // no output
+		array( 'display-block' => true )
+	);
+}
+
+add_action( 'wpcf7_upgrade', 'wpcf7_upgrade_recaptcha_v2_v3', 10, 2 );
+
+function wpcf7_upgrade_recaptcha_v2_v3( $new_ver, $old_ver ) {
+	if ( version_compare( '5.1-dev', $old_ver, '<=' ) ) {
+		return;
+	}
+
+	$service = WPCF7_RECAPTCHA::get_instance();
+
+	if ( ! $service->is_active() ) {
+		return;
+	}
+
+	// Maybe v2 keys are used now. Warning necessary.
+	WPCF7::update_option( 'recaptcha_v2_v3_warning', true );
+	WPCF7::update_option( 'recaptcha', null );
+}
+
+add_action( 'wpcf7_admin_menu', 'wpcf7_admin_init_recaptcha_v2_v3', 10, 0 );
+
+function wpcf7_admin_init_recaptcha_v2_v3() {
+	if ( ! WPCF7::get_option( 'recaptcha_v2_v3_warning' ) ) {
+		return;
+	}
+
+	add_filter( 'wpcf7_admin_menu_change_notice',
+		'wpcf7_admin_menu_change_notice_recaptcha_v2_v3', 10, 1 );
+
+	add_action( 'wpcf7_admin_warnings',
+		'wpcf7_admin_warnings_recaptcha_v2_v3', 5, 3 );
+}
+
+function wpcf7_admin_menu_change_notice_recaptcha_v2_v3( $counts ) {
+	$counts['wpcf7-integration'] += 1;
+	return $counts;
+}
+
+function wpcf7_admin_warnings_recaptcha_v2_v3( $page, $action, $object ) {
+	if ( 'wpcf7-integration' !== $page ) {
+		return;
+	}
+
+	$message = sprintf(
+		esc_html( __( "API keys for reCAPTCHA v3 are different from those for v2; keys for v2 don&#8217;t work with the v3 API. You need to register your sites again to get new keys for v3. For details, see %s.", 'contact-form-7' ) ),
+		wpcf7_link(
+			__( 'https://contactform7.com/recaptcha/', 'contact-form-7' ),
+			__( 'reCAPTCHA (v3)', 'contact-form-7' )
+		)
+	);
+
+	echo sprintf(
+		'<div class="notice notice-warning"><p>%s</p></div>',
+		$message
+	);
+}
+
+if ( ! class_exists( 'WPCF7_Service' ) ) {
+	return;
+}
+
+class WPCF7_RECAPTCHA extends WPCF7_Service {
 
 	private static $instance;
 	private $sitekeys;
+	private $last_score;
 
 	public static function get_instance() {
 		if ( empty( self::$instance ) ) {
@@ -37,13 +281,51 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 	}
 
 	public function link() {
-		echo sprintf( '<a href="%1$s">%2$s</a>',
+		echo wpcf7_link(
 			'https://www.google.com/recaptcha/intro/index.html',
-			'google.com/recaptcha' );
+			'google.com/recaptcha'
+		);
+	}
+
+	public function get_global_sitekey() {
+		static $sitekey = '';
+
+		if ( $sitekey ) {
+			return $sitekey;
+		}
+
+		if ( defined( 'WPCF7_RECAPTCHA_SITEKEY' ) ) {
+			$sitekey = WPCF7_RECAPTCHA_SITEKEY;
+		}
+
+		$sitekey = apply_filters( 'wpcf7_recaptcha_sitekey', $sitekey );
+
+		return $sitekey;
+	}
+
+	public function get_global_secret() {
+		static $secret = '';
+
+		if ( $secret ) {
+			return $secret;
+		}
+
+		if ( defined( 'WPCF7_RECAPTCHA_SECRET' ) ) {
+			$secret = WPCF7_RECAPTCHA_SECRET;
+		}
+
+		$secret = apply_filters( 'wpcf7_recaptcha_secret', $secret );
+
+		return $secret;
 	}
 
 	public function get_sitekey() {
-		if ( empty( $this->sitekeys ) || ! is_array( $this->sitekeys ) ) {
+		if ( $this->get_global_sitekey() && $this->get_global_secret() ) {
+			return $this->get_global_sitekey();
+		}
+
+		if ( empty( $this->sitekeys )
+		or ! is_array( $this->sitekeys ) ) {
 			return false;
 		}
 
@@ -53,6 +335,10 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 	}
 
 	public function get_secret( $sitekey ) {
+		if ( $this->get_global_sitekey() && $this->get_global_secret() ) {
+			return $this->get_global_secret();
+		}
+
 		$sitekeys = (array) $this->sitekeys;
 
 		if ( isset( $sitekeys[$sitekey] ) ) {
@@ -62,37 +348,72 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 		}
 	}
 
-	public function verify( $response_token ) {
+	protected function log( $url, $request, $response ) {
+		wpcf7_log_remote_request( $url, $request, $response );
+	}
+
+	public function verify( $token ) {
 		$is_human = false;
 
-		if ( empty( $response_token ) ) {
+		if ( empty( $token ) or ! $this->is_active() ) {
 			return $is_human;
 		}
 
-		$url = self::VERIFY_URL;
+		$endpoint = 'https://www.google.com/recaptcha/api/siteverify';
+
 		$sitekey = $this->get_sitekey();
 		$secret = $this->get_secret( $sitekey );
 
-		$response = wp_safe_remote_post( $url, array(
+		$request = array(
 			'body' => array(
 				'secret' => $secret,
-				'response' => $response_token,
-				'remoteip' => $_SERVER['REMOTE_ADDR'],
+				'response' => $token,
 			),
-		) );
+		);
+
+		$response = wp_remote_post( esc_url_raw( $endpoint ), $request );
 
 		if ( 200 != wp_remote_retrieve_response_code( $response ) ) {
+			if ( WP_DEBUG ) {
+				$this->log( $endpoint, $request, $response );
+			}
+
 			return $is_human;
 		}
 
-		$response = wp_remote_retrieve_body( $response );
-		$response = json_decode( $response, true );
+		$response_body = wp_remote_retrieve_body( $response );
+		$response_body = json_decode( $response_body, true );
 
-		$is_human = isset( $response['success'] ) && true == $response['success'];
+		$this->last_score = $score = isset( $response_body['score'] )
+			? $response_body['score']
+			: 0;
+
+		$threshold = $this->get_threshold();
+		$is_human = $threshold < $score;
+
+		$is_human = apply_filters( 'wpcf7_recaptcha_verify_response',
+			$is_human, $response_body );
+
+		if ( $submission = WPCF7_Submission::get_instance() ) {
+			$submission->recaptcha = array(
+				'version' => '3.0',
+				'threshold' => $threshold,
+				'response' => $response_body,
+			);
+		}
+
 		return $is_human;
 	}
 
-	private function menu_page_url( $args = '' ) {
+	public function get_threshold() {
+		return apply_filters( 'wpcf7_recaptcha_threshold', 0.50 );
+	}
+
+	public function get_last_score() {
+		return $this->last_score;
+	}
+
+	protected function menu_page_url( $args = '' ) {
 		$args = wp_parse_args( $args, array() );
 
 		$url = menu_page_url( 'wpcf7-integration', false );
@@ -105,21 +426,30 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 		return $url;
 	}
 
-	public function load( $action = '' ) {
-		if ( 'setup' == $action ) {
-			if ( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
-				check_admin_referer( 'wpcf7-recaptcha-setup' );
+	protected function save_data() {
+		WPCF7::update_option( 'recaptcha', $this->sitekeys );
+	}
 
+	protected function reset_data() {
+		$this->sitekeys = null;
+		$this->save_data();
+	}
+
+	public function load( $action = '' ) {
+		if ( 'setup' == $action and 'POST' == $_SERVER['REQUEST_METHOD'] ) {
+			check_admin_referer( 'wpcf7-recaptcha-setup' );
+
+			if ( ! empty( $_POST['reset'] ) ) {
+				$this->reset_data();
+				$redirect_to = $this->menu_page_url( 'action=setup' );
+			} else {
 				$sitekey = isset( $_POST['sitekey'] ) ? trim( $_POST['sitekey'] ) : '';
 				$secret = isset( $_POST['secret'] ) ? trim( $_POST['secret'] ) : '';
 
-				if ( $sitekey && $secret ) {
-					WPCF7::update_option( 'recaptcha', array( $sitekey => $secret ) );
-					$redirect_to = $this->menu_page_url( array(
-						'message' => 'success',
-					) );
-				} elseif ( '' === $sitekey && '' === $secret ) {
-					WPCF7::update_option( 'recaptcha', null );
+				if ( $sitekey and $secret ) {
+					$this->sitekeys = array( $sitekey => $secret );
+					$this->save_data();
+
 					$redirect_to = $this->menu_page_url( array(
 						'message' => 'success',
 					) );
@@ -129,10 +459,14 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 						'message' => 'invalid',
 					) );
 				}
-
-				wp_safe_redirect( $redirect_to );
-				exit();
 			}
+
+			if ( WPCF7::get_option( 'recaptcha_v2_v3_warning' ) ) {
+				WPCF7::update_option( 'recaptcha_v2_v3_warning', false );
+			}
+
+			wp_safe_redirect( $redirect_to );
+			exit();
 		}
 	}
 
@@ -151,47 +485,36 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 	}
 
 	public function display( $action = '' ) {
-?>
-<p><?php echo esc_html( __( "reCAPTCHA is a free service to protect your website from spam and abuse.", 'contact-form-7' ) ); ?></p>
-
-<?php
-		if ( 'setup' == $action ) {
-			$this->display_setup();
-			return;
-		}
+		echo '<p>' . sprintf(
+			esc_html( __( 'reCAPTCHA protects you against spam and other types of automated abuse. With Contact Form 7&#8217;s reCAPTCHA integration module, you can block abusive form submissions by spam bots. For details, see %s.', 'contact-form-7' ) ),
+			wpcf7_link(
+				__( 'https://contactform7.com/recaptcha/', 'contact-form-7' ),
+				__( 'reCAPTCHA (v3)', 'contact-form-7' )
+			)
+		) . '</p>';
 
 		if ( $this->is_active() ) {
-			$sitekey = $this->get_sitekey();
-			$secret = $this->get_secret( $sitekey );
-?>
-<table class="form-table">
-<tbody>
-<tr>
-	<th scope="row"><?php echo esc_html( __( 'Site Key', 'contact-form-7' ) ); ?></th>
-	<td class="code"><?php echo esc_html( $sitekey ); ?></td>
-</tr>
-<tr>
-	<th scope="row"><?php echo esc_html( __( 'Secret Key', 'contact-form-7' ) ); ?></th>
-	<td class="code"><?php echo esc_html( wpcf7_mask_password( $secret ) ); ?></td>
-</tr>
-</tbody>
-</table>
+			echo sprintf(
+				'<p class="dashicons-before dashicons-yes">%s</p>',
+				esc_html( __( "reCAPTCHA is active on this site.", 'contact-form-7' ) )
+			);
+		}
 
-<p><a href="<?php echo esc_url( $this->menu_page_url( 'action=setup' ) ); ?>" class="button"><?php echo esc_html( __( "Reset Keys", 'contact-form-7' ) ); ?></a></p>
-
-<?php
+		if ( 'setup' == $action ) {
+			$this->display_setup();
 		} else {
-?>
-<p><?php echo esc_html( __( "To use reCAPTCHA, you need to install an API key pair.", 'contact-form-7' ) ); ?></p>
-
-<p><a href="<?php echo esc_url( $this->menu_page_url( 'action=setup' ) ); ?>" class="button"><?php echo esc_html( __( "Configure Keys", 'contact-form-7' ) ); ?></a></p>
-
-<p><?php echo sprintf( esc_html( __( "For more details, see %s.", 'contact-form-7' ) ), wpcf7_link( __( 'https://contactform7.com/recaptcha/', 'contact-form-7' ), __( 'reCAPTCHA', 'contact-form-7' ) ) ); ?></p>
-<?php
+			echo sprintf(
+				'<p><a href="%1$s" class="button">%2$s</a></p>',
+				esc_url( $this->menu_page_url( 'action=setup' ) ),
+				esc_html( __( 'Setup Integration', 'contact-form-7' ) )
+			);
 		}
 	}
 
-	public function display_setup() {
+	private function display_setup() {
+		$sitekey = $this->is_active() ? $this->get_sitekey() : '';
+		$secret = $this->is_active() ? $this->get_secret( $sitekey ) : '';
+
 ?>
 <form method="post" action="<?php echo esc_url( $this->menu_page_url( 'action=setup' ) ); ?>">
 <?php wp_nonce_field( 'wpcf7-recaptcha-setup' ); ?>
@@ -199,317 +522,55 @@ class WPCF7_RECAPTCHA extends WPCF7_Service {
 <tbody>
 <tr>
 	<th scope="row"><label for="sitekey"><?php echo esc_html( __( 'Site Key', 'contact-form-7' ) ); ?></label></th>
-	<td><input type="text" aria-required="true" value="" id="sitekey" name="sitekey" class="regular-text code" /></td>
+	<td><?php
+		if ( $this->is_active() ) {
+			echo esc_html( $sitekey );
+			echo sprintf(
+				'<input type="hidden" value="%1$s" id="sitekey" name="sitekey" />',
+				esc_attr( $sitekey )
+			);
+		} else {
+			echo sprintf(
+				'<input type="text" aria-required="true" value="%1$s" id="sitekey" name="sitekey" class="regular-text code" />',
+				esc_attr( $sitekey )
+			);
+		}
+	?></td>
 </tr>
 <tr>
 	<th scope="row"><label for="secret"><?php echo esc_html( __( 'Secret Key', 'contact-form-7' ) ); ?></label></th>
-	<td><input type="text" aria-required="true" value="" id="secret" name="secret" class="regular-text code" /></td>
+	<td><?php
+		if ( $this->is_active() ) {
+			echo esc_html( wpcf7_mask_password( $secret ) );
+			echo sprintf(
+				'<input type="hidden" value="%1$s" id="secret" name="secret" />',
+				esc_attr( $secret )
+			);
+		} else {
+			echo sprintf(
+				'<input type="text" aria-required="true" value="%1$s" id="secret" name="secret" class="regular-text code" />',
+				esc_attr( $secret )
+			);
+		}
+	?></td>
 </tr>
 </tbody>
 </table>
-
-<p class="submit"><input type="submit" class="button button-primary" value="<?php echo esc_attr( __( 'Save', 'contact-form-7' ) ); ?>" name="submit" /></p>
+<?php
+		if ( $this->is_active() ) {
+			if ( $this->get_global_sitekey() && $this->get_global_secret() ) {
+				// nothing
+			} else {
+				submit_button(
+					_x( 'Remove Keys', 'API keys', 'contact-form-7' ),
+					'small', 'reset'
+				);
+			}
+		} else {
+			submit_button( __( 'Save Changes', 'contact-form-7' ) );
+		}
+?>
 </form>
 <?php
 	}
-}
-
-add_action( 'wpcf7_init', 'wpcf7_recaptcha_register_service' );
-
-function wpcf7_recaptcha_register_service() {
-	$integration = WPCF7_Integration::get_instance();
-
-	$categories = array(
-		'captcha' => __( 'CAPTCHA', 'contact-form-7' ),
-	);
-
-	foreach ( $categories as $name => $category ) {
-		$integration->add_category( $name, $category );
-	}
-
-	$services = array(
-		'recaptcha' => WPCF7_RECAPTCHA::get_instance(),
-	);
-
-	foreach ( $services as $name => $service ) {
-		$integration->add_service( $name, $service );
-	}
-}
-
-add_action( 'wpcf7_enqueue_scripts', 'wpcf7_recaptcha_enqueue_scripts' );
-
-function wpcf7_recaptcha_enqueue_scripts() {
-	$url = 'https://www.google.com/recaptcha/api.js';
-	$url = add_query_arg( array(
-		'onload' => 'recaptchaCallback',
-		'render' => 'explicit',
-	), $url );
-
-	wp_register_script( 'google-recaptcha', $url, array(), '2.0', true );
-}
-
-add_action( 'wp_footer', 'wpcf7_recaptcha_callback_script' );
-
-function wpcf7_recaptcha_callback_script() {
-	if ( ! wp_script_is( 'google-recaptcha', 'enqueued' ) ) {
-		return;
-	}
-
-?>
-<script type="text/javascript">
-var recaptchaWidgets = [];
-var recaptchaCallback = function() {
-	var forms = document.getElementsByTagName( 'form' );
-	var pattern = /(^|\s)g-recaptcha(\s|$)/;
-
-	for ( var i = 0; i < forms.length; i++ ) {
-		var divs = forms[ i ].getElementsByTagName( 'div' );
-
-		for ( var j = 0; j < divs.length; j++ ) {
-			var sitekey = divs[ j ].getAttribute( 'data-sitekey' );
-
-			if ( divs[ j ].className && divs[ j ].className.match( pattern ) && sitekey ) {
-				var params = {
-					'sitekey': sitekey,
-					'type': divs[ j ].getAttribute( 'data-type' ),
-					'size': divs[ j ].getAttribute( 'data-size' ),
-					'theme': divs[ j ].getAttribute( 'data-theme' ),
-					'badge': divs[ j ].getAttribute( 'data-badge' ),
-					'tabindex': divs[ j ].getAttribute( 'data-tabindex' )
-				};
-
-				var callback = divs[ j ].getAttribute( 'data-callback' );
-
-				if ( callback && 'function' == typeof window[ callback ] ) {
-					params[ 'callback' ] = window[ callback ];
-				}
-
-				var expired_callback = divs[ j ].getAttribute( 'data-expired-callback' );
-
-				if ( expired_callback && 'function' == typeof window[ expired_callback ] ) {
-					params[ 'expired-callback' ] = window[ expired_callback ];
-				}
-
-				var widget_id = grecaptcha.render( divs[ j ], params );
-				recaptchaWidgets.push( widget_id );
-				break;
-			}
-		}
-	}
-};
-
-document.addEventListener( 'wpcf7submit', function( event ) {
-	switch ( event.detail.status ) {
-		case 'spam':
-		case 'mail_sent':
-		case 'mail_failed':
-			for ( var i = 0; i < recaptchaWidgets.length; i++ ) {
-				grecaptcha.reset( recaptchaWidgets[ i ] );
-			}
-	}
-}, false );
-</script>
-<?php
-}
-
-add_action( 'wpcf7_init', 'wpcf7_recaptcha_add_form_tag_recaptcha' );
-
-function wpcf7_recaptcha_add_form_tag_recaptcha() {
-	$recaptcha = WPCF7_RECAPTCHA::get_instance();
-
-	if ( $recaptcha->is_active() ) {
-		wpcf7_add_form_tag( 'recaptcha', 'wpcf7_recaptcha_form_tag_handler',
-			array( 'display-block' => true ) );
-	}
-}
-
-function wpcf7_recaptcha_form_tag_handler( $tag ) {
-	if ( ! wp_script_is( 'google-recaptcha', 'registered' ) ) {
-		wpcf7_recaptcha_enqueue_scripts();
-	}
-
-	wp_enqueue_script( 'google-recaptcha' );
-
-	$atts = array();
-
-	$recaptcha = WPCF7_RECAPTCHA::get_instance();
-	$atts['data-sitekey'] = $recaptcha->get_sitekey();
-	$atts['data-type'] = $tag->get_option( 'type', '(audio|image)', true );
-	$atts['data-size'] = $tag->get_option(
-		'size', '(compact|normal|invisible)', true );
-	$atts['data-theme'] = $tag->get_option( 'theme', '(dark|light)', true );
-	$atts['data-badge'] = $tag->get_option(
-		'badge', '(bottomright|bottomleft|inline)', true );
-	$atts['data-tabindex'] = $tag->get_option( 'tabindex', 'signed_int', true );
-	$atts['data-callback'] = $tag->get_option( 'callback', '', true );
-	$atts['data-expired-callback'] =
-		$tag->get_option( 'expired_callback', '', true );
-
-	$atts['class'] = $tag->get_class_option(
-		wpcf7_form_controls_class( $tag->type, 'g-recaptcha' ) );
-	$atts['id'] = $tag->get_id_option();
-
-	$html = sprintf( '<div %1$s></div>', wpcf7_format_atts( $atts ) );
-	$html .= wpcf7_recaptcha_noscript(
-		array( 'sitekey' => $atts['data-sitekey'] ) );
-	$html = sprintf( '<div class="wpcf7-form-control-wrap">%s</div>', $html );
-
-	return $html;
-}
-
-function wpcf7_recaptcha_noscript( $args = '' ) {
-	$args = wp_parse_args( $args, array(
-		'sitekey' => '',
-	) );
-
-	if ( empty( $args['sitekey'] ) ) {
-		return;
-	}
-
-	$url = add_query_arg( 'k', $args['sitekey'],
-		'https://www.google.com/recaptcha/api/fallback' );
-
-	ob_start();
-?>
-
-<noscript>
-	<div style="width: 302px; height: 422px;">
-		<div style="width: 302px; height: 422px; position: relative;">
-			<div style="width: 302px; height: 422px; position: absolute;">
-				<iframe src="<?php echo esc_url( $url ); ?>" frameborder="0" scrolling="no" style="width: 302px; height:422px; border-style: none;">
-				</iframe>
-			</div>
-			<div style="width: 300px; height: 60px; border-style: none; bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px; background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
-				<textarea id="g-recaptcha-response" name="g-recaptcha-response" class="g-recaptcha-response" style="width: 250px; height: 40px; border: 1px solid #c1c1c1; margin: 10px 25px; padding: 0px; resize: none;">
-				</textarea>
-			</div>
-		</div>
-	</div>
-</noscript>
-<?php
-	return ob_get_clean();
-}
-
-add_filter( 'wpcf7_spam', 'wpcf7_recaptcha_check_with_google', 9 );
-
-function wpcf7_recaptcha_check_with_google( $spam ) {
-	if ( $spam ) {
-		return $spam;
-	}
-
-	$contact_form = wpcf7_get_current_contact_form();
-
-	if ( ! $contact_form ) {
-		return $spam;
-	}
-
-	$tags = $contact_form->scan_form_tags( array( 'type' => 'recaptcha' ) );
-
-	if ( empty( $tags ) ) {
-		return $spam;
-	}
-
-	$recaptcha = WPCF7_RECAPTCHA::get_instance();
-
-	if ( ! $recaptcha->is_active() ) {
-		return $spam;
-	}
-
-	$response_token = wpcf7_recaptcha_response();
-	$spam = ! $recaptcha->verify( $response_token );
-
-	return $spam;
-}
-
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_recaptcha', 45 );
-
-function wpcf7_add_tag_generator_recaptcha() {
-	$tag_generator = WPCF7_TagGenerator::get_instance();
-	$tag_generator->add( 'recaptcha', __( 'reCAPTCHA', 'contact-form-7' ),
-		'wpcf7_tag_generator_recaptcha', array( 'nameless' => 1 ) );
-}
-
-function wpcf7_tag_generator_recaptcha( $contact_form, $args = '' ) {
-	$args = wp_parse_args( $args, array() );
-
-	$recaptcha = WPCF7_RECAPTCHA::get_instance();
-
-	if ( ! $recaptcha->is_active() ) {
-?>
-<div class="control-box">
-<fieldset>
-<legend><?php echo sprintf( esc_html( __( "To use reCAPTCHA, first you need to install an API key pair. For more details, see %s.", 'contact-form-7' ) ), wpcf7_link( __( 'https://contactform7.com/recaptcha/', 'contact-form-7' ), __( 'reCAPTCHA', 'contact-form-7' ) ) ); ?></legend>
-</fieldset>
-</div>
-<?php
-
-		return;
-	}
-
-	$description = __( "Generate a form-tag for a reCAPTCHA widget. For more details, see %s.", 'contact-form-7' );
-
-	$desc_link = wpcf7_link( __( 'https://contactform7.com/recaptcha/', 'contact-form-7' ), __( 'reCAPTCHA', 'contact-form-7' ) );
-
-?>
-<div class="control-box">
-<fieldset>
-<legend><?php echo sprintf( esc_html( $description ), $desc_link ); ?></legend>
-
-<table class="form-table">
-<tbody>
-	<tr>
-	<th scope="row"><?php echo esc_html( __( 'Size', 'contact-form-7' ) ); ?></th>
-	<td>
-		<fieldset>
-		<legend class="screen-reader-text"><?php echo esc_html( __( 'Size', 'contact-form-7' ) ); ?></legend>
-		<label for="<?php echo esc_attr( $args['content'] . '-size-normal' ); ?>"><input type="radio" name="size" class="option default" id="<?php echo esc_attr( $args['content'] . '-size-normal' ); ?>" value="normal" checked="checked" /> <?php echo esc_html( __( 'Normal', 'contact-form-7' ) ); ?></label>
-		<br />
-		<label for="<?php echo esc_attr( $args['content'] . '-size-compact' ); ?>"><input type="radio" name="size" class="option" id="<?php echo esc_attr( $args['content'] . '-size-compact' ); ?>" value="compact" /> <?php echo esc_html( __( 'Compact', 'contact-form-7' ) ); ?></label>
-		</fieldset>
-	</td>
-	</tr>
-
-	<tr>
-	<th scope="row"><?php echo esc_html( __( 'Theme', 'contact-form-7' ) ); ?></th>
-	<td>
-		<fieldset>
-		<legend class="screen-reader-text"><?php echo esc_html( __( 'Theme', 'contact-form-7' ) ); ?></legend>
-		<label for="<?php echo esc_attr( $args['content'] . '-theme-light' ); ?>"><input type="radio" name="theme" class="option default" id="<?php echo esc_attr( $args['content'] . '-theme-light' ); ?>" value="light" checked="checked" /> <?php echo esc_html( __( 'Light', 'contact-form-7' ) ); ?></label>
-		<br />
-		<label for="<?php echo esc_attr( $args['content'] . '-theme-dark' ); ?>"><input type="radio" name="theme" class="option" id="<?php echo esc_attr( $args['content'] . '-theme-dark' ); ?>" value="dark" /> <?php echo esc_html( __( 'Dark', 'contact-form-7' ) ); ?></label>
-		</fieldset>
-	</td>
-	</tr>
-
-	<tr>
-	<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-id' ); ?>"><?php echo esc_html( __( 'Id attribute', 'contact-form-7' ) ); ?></label></th>
-	<td><input type="text" name="id" class="idvalue oneline option" id="<?php echo esc_attr( $args['content'] . '-id' ); ?>" /></td>
-	</tr>
-
-	<tr>
-	<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-class' ); ?>"><?php echo esc_html( __( 'Class attribute', 'contact-form-7' ) ); ?></label></th>
-	<td><input type="text" name="class" class="classvalue oneline option" id="<?php echo esc_attr( $args['content'] . '-class' ); ?>" /></td>
-	</tr>
-
-</tbody>
-</table>
-</fieldset>
-</div>
-
-<div class="insert-box">
-	<input type="text" name="recaptcha" class="tag code" readonly="readonly" onfocus="this.select()" />
-
-	<div class="submitbox">
-	<input type="button" class="button button-primary insert-tag" value="<?php echo esc_attr( __( 'Insert Tag', 'contact-form-7' ) ); ?>" />
-	</div>
-</div>
-<?php
-}
-
-function wpcf7_recaptcha_response() {
-	if ( isset( $_POST['g-recaptcha-response'] ) ) {
-		return $_POST['g-recaptcha-response'];
-	}
-
-	return false;
 }

--- a/wp-content/plugins/contact-form-7/modules/response.php
+++ b/wp-content/plugins/contact-form-7/modules/response.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_response' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_response', 10, 0 );
 
 function wpcf7_add_form_tag_response() {
 	wpcf7_add_form_tag( 'response', 'wpcf7_response_form_tag_handler',

--- a/wp-content/plugins/contact-form-7/modules/select.php
+++ b/wp-content/plugins/contact-form-7/modules/select.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_select' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_select', 10, 0 );
 
 function wpcf7_add_form_tag_select() {
 	wpcf7_add_form_tag( array( 'select', 'select*' ),
@@ -58,20 +58,21 @@ function wpcf7_select_form_tag_handler( $tag ) {
 		}
 	}
 
+	if ( $data = (array) $tag->get_data_option() ) {
+		$tag->values = array_merge( $tag->values, array_values( $data ) );
+		$tag->labels = array_merge( $tag->labels, array_values( $data ) );
+	}
+
 	$values = $tag->values;
 	$labels = $tag->labels;
-
-	if ( $data = (array) $tag->get_data_option() ) {
-		$values = array_merge( $values, array_values( $data ) );
-		$labels = array_merge( $labels, array_values( $data ) );
-	}
 
 	$default_choice = $tag->get_default_option( null, array(
 		'multiple' => $multiple,
 		'shifted' => $include_blank,
 	) );
 
-	if ( $include_blank || empty( $values ) ) {
+	if ( $include_blank
+	or empty( $values ) ) {
 		array_unshift( $labels, '---' );
 		array_unshift( $values, '' );
 	} elseif ( $first_as_label ) {
@@ -125,7 +126,8 @@ add_filter( 'wpcf7_validate_select*', 'wpcf7_select_validation_filter', 10, 2 );
 function wpcf7_select_validation_filter( $result, $tag ) {
 	$name = $tag->name;
 
-	if ( isset( $_POST[$name] ) && is_array( $_POST[$name] ) ) {
+	if ( isset( $_POST[$name] )
+	and is_array( $_POST[$name] ) ) {
 		foreach ( $_POST[$name] as $key => $value ) {
 			if ( '' === $value ) {
 				unset( $_POST[$name][$key] );
@@ -135,7 +137,7 @@ function wpcf7_select_validation_filter( $result, $tag ) {
 
 	$empty = ! isset( $_POST[$name] ) || empty( $_POST[$name] ) && '0' !== $_POST[$name];
 
-	if ( $tag->is_required() && $empty ) {
+	if ( $tag->is_required() and $empty ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
 	}
 
@@ -145,7 +147,7 @@ function wpcf7_select_validation_filter( $result, $tag ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_menu', 25 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_menu', 25, 0 );
 
 function wpcf7_add_tag_generator_menu() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/submit.php
+++ b/wp-content/plugins/contact-form-7/modules/submit.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_submit' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_submit', 10, 0 );
 
 function wpcf7_add_form_tag_submit() {
 	wpcf7_add_form_tag( 'submit', 'wpcf7_submit_form_tag_handler' );
@@ -39,7 +39,7 @@ function wpcf7_submit_form_tag_handler( $tag ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_submit', 55 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_submit', 55, 0 );
 
 function wpcf7_add_tag_generator_submit() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/text.php
+++ b/wp-content/plugins/contact-form-7/modules/text.php
@@ -9,7 +9,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_text' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_text', 10, 0 );
 
 function wpcf7_add_form_tag_text() {
 	wpcf7_add_form_tag(
@@ -40,8 +40,8 @@ function wpcf7_text_form_tag_handler( $tag ) {
 	$atts['maxlength'] = $tag->get_maxlength_option();
 	$atts['minlength'] = $tag->get_minlength_option();
 
-	if ( $atts['maxlength'] && $atts['minlength']
-	&& $atts['maxlength'] < $atts['minlength'] ) {
+	if ( $atts['maxlength'] and $atts['minlength']
+	and $atts['maxlength'] < $atts['minlength'] ) {
 		unset( $atts['maxlength'], $atts['minlength'] );
 	}
 
@@ -64,7 +64,8 @@ function wpcf7_text_form_tag_handler( $tag ) {
 
 	$value = (string) reset( $tag->values );
 
-	if ( $tag->has_option( 'placeholder' ) || $tag->has_option( 'watermark' ) ) {
+	if ( $tag->has_option( 'placeholder' )
+	or $tag->has_option( 'watermark' ) ) {
 		$atts['placeholder'] = $value;
 		$value = '';
 	}
@@ -112,31 +113,31 @@ function wpcf7_text_validation_filter( $result, $tag ) {
 		: '';
 
 	if ( 'text' == $tag->basetype ) {
-		if ( $tag->is_required() && '' == $value ) {
+		if ( $tag->is_required() and '' == $value ) {
 			$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
 		}
 	}
 
 	if ( 'email' == $tag->basetype ) {
-		if ( $tag->is_required() && '' == $value ) {
+		if ( $tag->is_required() and '' == $value ) {
 			$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
-		} elseif ( '' != $value && ! wpcf7_is_email( $value ) ) {
+		} elseif ( '' != $value and ! wpcf7_is_email( $value ) ) {
 			$result->invalidate( $tag, wpcf7_get_message( 'invalid_email' ) );
 		}
 	}
 
 	if ( 'url' == $tag->basetype ) {
-		if ( $tag->is_required() && '' == $value ) {
+		if ( $tag->is_required() and '' == $value ) {
 			$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
-		} elseif ( '' != $value && ! wpcf7_is_url( $value ) ) {
+		} elseif ( '' != $value and ! wpcf7_is_url( $value ) ) {
 			$result->invalidate( $tag, wpcf7_get_message( 'invalid_url' ) );
 		}
 	}
 
 	if ( 'tel' == $tag->basetype ) {
-		if ( $tag->is_required() && '' == $value ) {
+		if ( $tag->is_required() and '' == $value ) {
 			$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
-		} elseif ( '' != $value && ! wpcf7_is_tel( $value ) ) {
+		} elseif ( '' != $value and ! wpcf7_is_tel( $value ) ) {
 			$result->invalidate( $tag, wpcf7_get_message( 'invalid_tel' ) );
 		}
 	}
@@ -145,16 +146,16 @@ function wpcf7_text_validation_filter( $result, $tag ) {
 		$maxlength = $tag->get_maxlength_option();
 		$minlength = $tag->get_minlength_option();
 
-		if ( $maxlength && $minlength && $maxlength < $minlength ) {
+		if ( $maxlength and $minlength and $maxlength < $minlength ) {
 			$maxlength = $minlength = null;
 		}
 
 		$code_units = wpcf7_count_code_units( stripslashes( $value ) );
 
 		if ( false !== $code_units ) {
-			if ( $maxlength && $maxlength < $code_units ) {
+			if ( $maxlength and $maxlength < $code_units ) {
 				$result->invalidate( $tag, wpcf7_get_message( 'invalid_too_long' ) );
-			} elseif ( $minlength && $code_units < $minlength ) {
+			} elseif ( $minlength and $code_units < $minlength ) {
 				$result->invalidate( $tag, wpcf7_get_message( 'invalid_too_short' ) );
 			}
 		}
@@ -166,7 +167,7 @@ function wpcf7_text_validation_filter( $result, $tag ) {
 
 /* Messages */
 
-add_filter( 'wpcf7_messages', 'wpcf7_text_messages' );
+add_filter( 'wpcf7_messages', 'wpcf7_text_messages', 10, 1 );
 
 function wpcf7_text_messages( $messages ) {
 	$messages = array_merge( $messages, array(
@@ -198,7 +199,7 @@ function wpcf7_text_messages( $messages ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_text', 15 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_text', 15, 0 );
 
 function wpcf7_add_tag_generator_text() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/modules/textarea.php
+++ b/wp-content/plugins/contact-form-7/modules/textarea.php
@@ -5,7 +5,7 @@
 
 /* form_tag handler */
 
-add_action( 'wpcf7_init', 'wpcf7_add_form_tag_textarea' );
+add_action( 'wpcf7_init', 'wpcf7_add_form_tag_textarea', 10, 0 );
 
 function wpcf7_add_form_tag_textarea() {
 	wpcf7_add_form_tag( array( 'textarea', 'textarea*' ),
@@ -32,7 +32,8 @@ function wpcf7_textarea_form_tag_handler( $tag ) {
 	$atts['maxlength'] = $tag->get_maxlength_option();
 	$atts['minlength'] = $tag->get_minlength_option();
 
-	if ( $atts['maxlength'] && $atts['minlength'] && $atts['maxlength'] < $atts['minlength'] ) {
+	if ( $atts['maxlength'] and $atts['minlength']
+	and $atts['maxlength'] < $atts['minlength'] ) {
 		unset( $atts['maxlength'], $atts['minlength'] );
 	}
 
@@ -57,7 +58,8 @@ function wpcf7_textarea_form_tag_handler( $tag ) {
 		? (string) reset( $tag->values )
 		: $tag->content;
 
-	if ( $tag->has_option( 'placeholder' ) || $tag->has_option( 'watermark' ) ) {
+	if ( $tag->has_option( 'placeholder' )
+	or $tag->has_option( 'watermark' ) ) {
 		$atts['placeholder'] = $value;
 		$value = '';
 	}
@@ -81,8 +83,10 @@ function wpcf7_textarea_form_tag_handler( $tag ) {
 
 /* Validation filter */
 
-add_filter( 'wpcf7_validate_textarea', 'wpcf7_textarea_validation_filter', 10, 2 );
-add_filter( 'wpcf7_validate_textarea*', 'wpcf7_textarea_validation_filter', 10, 2 );
+add_filter( 'wpcf7_validate_textarea',
+	'wpcf7_textarea_validation_filter', 10, 2 );
+add_filter( 'wpcf7_validate_textarea*',
+	'wpcf7_textarea_validation_filter', 10, 2 );
 
 function wpcf7_textarea_validation_filter( $result, $tag ) {
 	$type = $tag->type;
@@ -90,7 +94,7 @@ function wpcf7_textarea_validation_filter( $result, $tag ) {
 
 	$value = isset( $_POST[$name] ) ? (string) $_POST[$name] : '';
 
-	if ( $tag->is_required() && '' == $value ) {
+	if ( $tag->is_required() and '' == $value ) {
 		$result->invalidate( $tag, wpcf7_get_message( 'invalid_required' ) );
 	}
 
@@ -98,16 +102,17 @@ function wpcf7_textarea_validation_filter( $result, $tag ) {
 		$maxlength = $tag->get_maxlength_option();
 		$minlength = $tag->get_minlength_option();
 
-		if ( $maxlength && $minlength && $maxlength < $minlength ) {
+		if ( $maxlength and $minlength
+		and $maxlength < $minlength ) {
 			$maxlength = $minlength = null;
 		}
 
 		$code_units = wpcf7_count_code_units( stripslashes( $value ) );
 
 		if ( false !== $code_units ) {
-			if ( $maxlength && $maxlength < $code_units ) {
+			if ( $maxlength and $maxlength < $code_units ) {
 				$result->invalidate( $tag, wpcf7_get_message( 'invalid_too_long' ) );
-			} elseif ( $minlength && $code_units < $minlength ) {
+			} elseif ( $minlength and $code_units < $minlength ) {
 				$result->invalidate( $tag, wpcf7_get_message( 'invalid_too_short' ) );
 			}
 		}
@@ -119,7 +124,7 @@ function wpcf7_textarea_validation_filter( $result, $tag ) {
 
 /* Tag generator */
 
-add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_textarea', 20 );
+add_action( 'wpcf7_admin_init', 'wpcf7_add_tag_generator_textarea', 20, 0 );
 
 function wpcf7_add_tag_generator_textarea() {
 	$tag_generator = WPCF7_TagGenerator::get_instance();

--- a/wp-content/plugins/contact-form-7/readme.txt
+++ b/wp-content/plugins/contact-form-7/readme.txt
@@ -2,9 +2,9 @@
 Contributors: takayukister
 Donate link: https://contactform7.com/donate/
 Tags: contact, form, contact form, feedback, email, ajax, captcha, akismet, multilingual
-Requires at least: 4.8
-Tested up to: 4.9
-Stable tag: 5.0.3
+Requires at least: 4.9
+Tested up to: 5.3
+Stable tag: 5.1.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,7 @@ If you activate certain features in this plugin, the contact form submitter's pe
 
 * reCAPTCHA ([Google](https://policies.google.com/?hl=en))
 * Akismet ([Automattic](https://automattic.com/privacy/))
+* Constant Contact ([Endurance International Group](https://www.endurance.com/privacy))
 
 = Recommended Plugins =
 
@@ -73,6 +74,60 @@ Do you have questions or issues with Contact Form 7? Use these support channels 
 == Changelog ==
 
 For more information, see [Releases](https://contactform7.com/category/releases/).
+
+= 5.1.6 =
+
+* CSS: removes a style rule from the stylesheet that was unnecessary and conflicting with Twenty Twenty’s rules.
+* REST API: retrieves the contact form ID explicitly from the route parameters.
+
+= 5.1.5 =
+
+* Config Validator: New test item for the unavailable_html_elements error.
+* Config Validator: New test item for the attachments_overweight error.
+
+= 5.1.4 =
+
+* reCAPTCHA: introduces the WPCF7_RECAPTCHA_SITEKEY and WPCF7_RECAPTCHA_SECRET constants.
+* reCAPTCHA: Introduces the wpcf7_recaptcha_sitekey and wpcf7_recaptcha_secret filter hooks.
+* Adds $status parameter to the wpcf7_form_response_output filter.
+* Creates a nonce only when the submitter is a logged-in user.
+* Introduces WPCF7_ContactForm::unit_tag(), a public method that returns a unit tag.
+* reCAPTCHA: gives a different spam log message for cases where the response token is empty.
+* Acceptance Checkbox: supports the label_first option in an acceptance form-tag.
+
+= 5.1.3 =
+
+* Fixes a bug making it unable to unselect an option in the Mail tab panel.
+
+= 5.1.2 =
+
+* Constant Contact: Introduces the contact list selector.
+* Constant Contact: Introduces the constant_contact additional setting.
+* reCAPTCHA: Introduces the wpcf7_recaptcha_actions and wpcf7_recaptcha_threshold filter hooks.
+
+= 5.1.1 =
+
+* reCAPTCHA: Modifies the reaction to empty response tokens.
+
+= 5.1 =
+
+* Introduces the Constant Contact integration module.
+* Updates the reCAPTCHA module to support reCAPTCHA v3.
+* Adds Dark Mode style rules.
+
+= 5.0.5 =
+
+* Fixes the inconsistency problem between get_data_option() and get_default_option() in the WPCF7_FormTag class.
+* Suppresses PHP errors occur on unlink() calls.
+* Introduces wpcf7_is_file_path_in_content_dir() to support the use of the UPLOADS constant.
+
+= 5.0.4 =
+
+* Specifies the capability_type argument explicitly in the register_post_type() call to fix the privilege escalation vulnerability issue.
+* Local File Attachment – disallows the specifying of absolute file paths referring to files outside the wp-content directory.
+* Config Validator – adds a test item to detect invalid file attachment settings.
+* Fixes a bug in the JavaScript fallback function for legacy browsers that do not support the HTML5 placeholder attribute.
+* Acceptance Checkbox – unsets the form-tag's do-not-store feature.
 
 = 5.0.3 =
 
@@ -113,3 +168,13 @@ For more information, see [Releases](https://contactform7.com/category/releases/
 * New special mail tags: [_site_title], [_site_description], [_site_url], [_site_admin_email], [_invalid_fields], [_user_login], [_user_email], [_user_url], [_user_first_name], [_user_last_name], [_user_nickname], and [_user_display_name]
 * New filter hooks: wpcf7_upload_file_name, wpcf7_autop_or_not, wpcf7_posted_data_{$type}, and wpcf7_mail_tag_replaced_{$type}
 * New form-tag features: zero-controls-container and not-for-mail
+
+== Upgrade Notice ==
+
+= 5.1.1 =
+
+Read the [release announcement post](https://contactform7.com/category/releases/) before upgrading. There is an important notice.
+
+= 5.0.4 =
+
+This is a security and maintenance release and we strongly encourage you to update to it immediately. For more information, refer to the [release announcement post](https://contactform7.com/category/releases/).

--- a/wp-content/plugins/contact-form-7/settings.php
+++ b/wp-content/plugins/contact-form-7/settings.php
@@ -31,10 +31,12 @@ class WPCF7 {
 		self::load_module( 'acceptance' );
 		self::load_module( 'akismet' );
 		self::load_module( 'checkbox' );
+		self::load_module( 'constant-contact' );
 		self::load_module( 'count' );
 		self::load_module( 'date' );
 		self::load_module( 'file' );
 		self::load_module( 'flamingo' );
+		self::load_module( 'hidden' );
 		self::load_module( 'listo' );
 		self::load_module( 'number' );
 		self::load_module( 'quiz' );
@@ -45,13 +47,12 @@ class WPCF7 {
 		self::load_module( 'submit' );
 		self::load_module( 'text' );
 		self::load_module( 'textarea' );
-		self::load_module( 'hidden' );
 	}
 
 	protected static function load_module( $mod ) {
 		$dir = WPCF7_PLUGIN_MODULES_DIR;
 
-		if ( empty( $dir ) || ! is_dir( $dir ) ) {
+		if ( empty( $dir ) or ! is_dir( $dir ) ) {
 			return false;
 		}
 
@@ -84,7 +85,7 @@ class WPCF7 {
 	}
 }
 
-add_action( 'plugins_loaded', 'wpcf7' );
+add_action( 'plugins_loaded', 'wpcf7', 10, 0 );
 
 function wpcf7() {
 	wpcf7_load_textdomain();
@@ -95,7 +96,7 @@ function wpcf7() {
 	add_shortcode( 'contact-form', 'wpcf7_contact_form_tag_func' );
 }
 
-add_action( 'init', 'wpcf7_init' );
+add_action( 'init', 'wpcf7_init', 10, 0 );
 
 function wpcf7_init() {
 	wpcf7_get_request_uri();
@@ -104,7 +105,7 @@ function wpcf7_init() {
 	do_action( 'wpcf7_init' );
 }
 
-add_action( 'admin_init', 'wpcf7_upgrade' );
+add_action( 'admin_init', 'wpcf7_upgrade', 10, 0 );
 
 function wpcf7_upgrade() {
 	$old_ver = WPCF7::get_option( 'version', '0' );
@@ -121,7 +122,7 @@ function wpcf7_upgrade() {
 
 /* Install and default settings */
 
-add_action( 'activate_' . WPCF7_PLUGIN_BASENAME, 'wpcf7_install' );
+add_action( 'activate_' . WPCF7_PLUGIN_BASENAME, 'wpcf7_install', 10, 0 );
 
 function wpcf7_install() {
 	if ( $opt = get_option( 'wpcf7' ) ) {

--- a/wp-content/plugins/contact-form-7/wp-contact-form-7.php
+++ b/wp-content/plugins/contact-form-7/wp-contact-form-7.php
@@ -7,12 +7,12 @@ Author: Takayuki Miyoshi
 Author URI: https://ideasilo.wordpress.com/
 Text Domain: contact-form-7
 Domain Path: /languages/
-Version: 5.0.3
+Version: 5.1.6
 */
 
-define( 'WPCF7_VERSION', '5.0.3' );
+define( 'WPCF7_VERSION', '5.1.6' );
 
-define( 'WPCF7_REQUIRED_WP_VERSION', '4.8' );
+define( 'WPCF7_REQUIRED_WP_VERSION', '4.9' );
 
 define( 'WPCF7_PLUGIN', __FILE__ );
 
@@ -61,6 +61,7 @@ if ( ! defined( 'WPCF7_VALIDATE_CONFIGURATION' ) ) {
 }
 
 // Deprecated, not used in the plugin core. Use wpcf7_plugin_url() instead.
-define( 'WPCF7_PLUGIN_URL', untrailingslashit( plugins_url( '', WPCF7_PLUGIN ) ) );
+define( 'WPCF7_PLUGIN_URL',
+	untrailingslashit( plugins_url( '', WPCF7_PLUGIN ) ) );
 
 require_once WPCF7_PLUGIN_DIR . '/settings.php';


### PR DESCRIPTION
We were getting a lot of spam in spite of the reCaptcha v2

updating Contact Form to 5.1.x allows using reCaptcha v3. Worth a shot if that helps!
more info e.g. here https://contactform7.com/recaptcha/

it actually is supposed to work without "I am not a robot" checkbox. We'll see! :)