### PR TITLE
Congress-related changes

### DIFF
--- a/wp-content/themes/Parallax-One/front-page.php
+++ b/wp-content/themes/Parallax-One/front-page.php
@@ -18,126 +18,156 @@
         array_push($not_hidden_sections, 'sections/parallax_one_introduction_section');
       endif;
 
-      // temporary fix for Language4Water - Image section after Introduction section
-      if ($sitePath == '/glasgow/language/') {
-        $parallax_one_image_section_show = get_theme_mod('parallax_one_image_section_show', DefImage::$hide);
-        if (isset($parallax_one_image_section_show) && $parallax_one_image_section_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_image_section');
-        endif;
+      if ($sitePath == '/prague-congress/') {
+          $parallax_one_why_us_show = get_theme_mod('parallax_one_why_us_show');
+          if (isset($parallax_one_why_us_show) && $parallax_one_why_us_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_why_us_section');
+          endif;
+
+          $parallax_one_image_section_show = get_theme_mod('parallax_one_image_section_show', DefImage::$hide);
+          if (isset($parallax_one_image_section_show) && $parallax_one_image_section_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_image_section');
+          endif;
+
+          $parallax_one_faq_show = get_theme_mod('parallax_one_faq_show', DefFaq::$hide);
+          if (isset($parallax_one_faq_show) && $parallax_one_faq_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_faq_section');
+          endif;
+
+          array_push($not_hidden_sections, 'sections/parallax_one_congress_section');
+
+          $parallax_one_contact_show = get_theme_mod('parallax_one_contact_show');
+          if (isset($parallax_one_contact_show) && $parallax_one_contact_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_contact_section');
+          endif;
+
+          $parallax_one_map_show = get_theme_mod('parallax_one_map_show');
+          if (isset($parallax_one_map_show) && $parallax_one_map_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_map_section');
+          endif;
+      } else {
+
+          // temporary fix for Language4Water - Image section after Introduction section
+          if ($sitePath == '/glasgow/language/') {
+              $parallax_one_image_section_show = get_theme_mod('parallax_one_image_section_show', DefImage::$hide);
+              if (isset($parallax_one_image_section_show) && $parallax_one_image_section_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_image_section');
+              endif;
+          }
+
+          $parallax_one_which_style_show = get_theme_mod('parallax_one_which_style_show');
+          if (isset($parallax_one_which_style_show) && $parallax_one_which_style_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_which_style_section');
+          endif;
+
+          // temporary fix for 4Water to have Why us section in the right place
+          if ($sitePath != '/') {
+              $parallax_one_why_us_show = get_theme_mod('parallax_one_why_us_show');
+              if (isset($parallax_one_why_us_show) && $parallax_one_why_us_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_why_us_section');
+              endif;
+          }
+
+          // temporary fix for 4Water to have Many things section in the right place
+          if ($sitePath == '/') {
+              $parallax_one_many_things_show = get_theme_mod('parallax_one_many_things_show', DefImage::$hide);
+              if (isset($parallax_one_many_things_show) && $parallax_one_many_things_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_many_things_section');
+              endif;
+          }
+
+          $parallax_one_video_show = get_theme_mod('parallax_one_video_show', DefVideo::$hide);
+          if (isset($parallax_one_video_show) && $parallax_one_video_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_video_section');
+          endif;
+
+          $parallax_one_call_to_action_show = get_theme_mod('parallax_one_call_to_action_show', DefCallToAction::$hide);
+          if (isset($parallax_one_call_to_action_show) && $parallax_one_call_to_action_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_call_to_action_section');
+          endif;
+
+          $parallax_one_how_we_teach_show = get_theme_mod('parallax_one_how_we_teach_show');
+          if (isset($parallax_one_how_we_teach_show) && $parallax_one_how_we_teach_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_how_we_teach_section');
+          endif;
+
+          $parallax_one_faq_show = get_theme_mod('parallax_one_faq_show', DefFaq::$hide);
+          if (isset($parallax_one_faq_show) && $parallax_one_faq_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_faq_section');
+          endif;
+
+          // temporary fix for 4Water to have Many things section in the right place
+          if ($sitePath != '/') {
+              $parallax_one_many_things_show = get_theme_mod('parallax_one_many_things_show');
+              if (isset($parallax_one_many_things_show) && $parallax_one_many_things_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_many_things_section');
+              endif;
+          }
+
+          $parallax_one_prices_show = get_theme_mod('parallax_one_prices_show');
+          if (isset($parallax_one_prices_show) && $parallax_one_prices_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_prices_section');
+          endif;
+
+          $parallax_one_team_show = get_theme_mod('parallax_one_team_show', DefTeam::$hide);
+          if (isset($parallax_one_team_show) && $parallax_one_team_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_our_team_section');
+          endif;
+
+          // temporary fix for Language4Water and 4Water to have Image section in the right place
+          if (($sitePath != '/glasgow/language/') && ($sitePath != '/')) {
+              $parallax_one_image_section_show = get_theme_mod('parallax_one_image_section_show', DefImage::$hide);
+              if (isset($parallax_one_image_section_show) && $parallax_one_image_section_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_image_section');
+              endif;
+          }
+
+          $parallax_one_calendar_show = get_theme_mod('parallax_one_calendar_show');
+          if (isset($parallax_one_calendar_show) && $parallax_one_calendar_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_calendar_section');
+          endif;
+
+          // temporary fix for 4Water to have Articles section in the right place
+          if ($sitePath != '/') {
+              $parallax_one_articles_section_show = get_theme_mod('parallax_one_articles_show', DefArticles::$hide);
+              if (isset($parallax_one_articles_section_show) && $parallax_one_articles_section_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_articles_section');
+              endif;
+          }
+
+          $parallax_one_subscription_show = get_theme_mod('parallax_one_subscription_section_show');
+          if (isset($parallax_one_subscription_show) && $parallax_one_subscription_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_subscription_section');
+          endif;
+
+          $parallax_one_map_show = get_theme_mod('parallax_one_map_show');
+          if (isset($parallax_one_map_show) && $parallax_one_map_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_map_section');
+          endif;
+
+          // temporary fix for 4Water - Why us, Image and Articles sections after Map section
+          if ($sitePath == '/') {
+              $parallax_one_why_us_show = get_theme_mod('parallax_one_why_us_show');
+              if (isset($parallax_one_why_us_show) && $parallax_one_why_us_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_why_us_section');
+              endif;
+
+              $parallax_one_image_section_show = get_theme_mod('parallax_one_image_section_show', DefImage::$hide);
+              if (isset($parallax_one_image_section_show) && $parallax_one_image_section_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_image_section');
+              endif;
+
+              $parallax_one_articles_section_show = get_theme_mod('parallax_one_articles_show', DefArticles::$hide);
+              if (isset($parallax_one_articles_section_show) && $parallax_one_articles_section_show != 1):
+                  array_push($not_hidden_sections, 'sections/parallax_one_articles_section');
+              endif;
+          }
+
+          $parallax_one_contact_show = get_theme_mod('parallax_one_contact_show');
+          if (isset($parallax_one_contact_show) && $parallax_one_contact_show != 1):
+              array_push($not_hidden_sections, 'sections/parallax_one_contact_section');
+          endif;
       }
-
-      $parallax_one_which_style_show = get_theme_mod('parallax_one_which_style_show');
-      if (isset($parallax_one_which_style_show) && $parallax_one_which_style_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_which_style_section');
-      endif;
-
-      // temporary fix for 4Water to have Why us section in the right place
-      if ($sitePath != '/') {
-        $parallax_one_why_us_show = get_theme_mod('parallax_one_why_us_show');
-        if (isset($parallax_one_why_us_show) && $parallax_one_why_us_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_why_us_section');
-        endif;
-      }
-
-      // temporary fix for 4Water to have Many things section in the right place
-      if ($sitePath == '/') {
-        $parallax_one_many_things_show = get_theme_mod('parallax_one_many_things_show', DefImage::$hide);
-        if (isset($parallax_one_many_things_show) && $parallax_one_many_things_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_many_things_section');
-        endif;
-      }
-
-      $parallax_one_video_show = get_theme_mod('parallax_one_video_show', DefVideo::$hide);
-      if (isset($parallax_one_video_show) && $parallax_one_video_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_video_section');
-      endif;
-
-      $parallax_one_call_to_action_show = get_theme_mod('parallax_one_call_to_action_show', DefCallToAction::$hide);
-      if (isset($parallax_one_call_to_action_show) && $parallax_one_call_to_action_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_call_to_action_section');
-      endif;
-
-      $parallax_one_how_we_teach_show = get_theme_mod('parallax_one_how_we_teach_show');
-      if (isset($parallax_one_how_we_teach_show) && $parallax_one_how_we_teach_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_how_we_teach_section');
-      endif;
-
-      $parallax_one_faq_show = get_theme_mod('parallax_one_faq_show', DefFaq::$hide);
-      if (isset($parallax_one_faq_show) && $parallax_one_faq_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_faq_section');
-      endif;
-
-      // temporary fix for 4Water to have Many things section in the right place
-      if ($sitePath != '/') {
-        $parallax_one_many_things_show = get_theme_mod('parallax_one_many_things_show');
-        if (isset($parallax_one_many_things_show) && $parallax_one_many_things_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_many_things_section');
-        endif;
-      }
-
-      $parallax_one_prices_show = get_theme_mod('parallax_one_prices_show');
-      if (isset($parallax_one_prices_show) && $parallax_one_prices_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_prices_section');
-      endif;
-
-      $parallax_one_team_show = get_theme_mod('parallax_one_team_show', DefTeam::$hide);
-      if (isset($parallax_one_team_show) && $parallax_one_team_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_our_team_section');
-      endif;
-
-      // temporary fix for Language4Water and 4Water to have Image section in the right place
-      if (($sitePath != '/glasgow/language/') && ($sitePath != '/')) {
-        $parallax_one_image_section_show = get_theme_mod('parallax_one_image_section_show', DefImage::$hide);
-        if (isset($parallax_one_image_section_show) && $parallax_one_image_section_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_image_section');
-        endif;
-      }
-
-      $parallax_one_calendar_show = get_theme_mod('parallax_one_calendar_show');
-      if (isset($parallax_one_calendar_show) && $parallax_one_calendar_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_calendar_section');
-      endif;
-
-      // temporary fix for 4Water to have Articles section in the right place
-      if ($sitePath != '/') {
-        $parallax_one_articles_section_show = get_theme_mod('parallax_one_articles_show', DefArticles::$hide);
-        if (isset($parallax_one_articles_section_show) && $parallax_one_articles_section_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_articles_section');
-        endif;
-      }
-
-      $parallax_one_subscription_show = get_theme_mod('parallax_one_subscription_section_show');
-      if (isset($parallax_one_subscription_show) && $parallax_one_subscription_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_subscription_section');
-      endif;
-
-      $parallax_one_map_show = get_theme_mod('parallax_one_map_show');
-      if (isset($parallax_one_map_show) && $parallax_one_map_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_map_section');
-      endif;
-
-      // temporary fix for 4Water - Why us, Image and Articles sections after Map section
-      if ($sitePath == '/') {
-        $parallax_one_why_us_show = get_theme_mod('parallax_one_why_us_show');
-        if (isset($parallax_one_why_us_show) && $parallax_one_why_us_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_why_us_section');
-        endif;
-
-        $parallax_one_image_section_show = get_theme_mod('parallax_one_image_section_show', DefImage::$hide);
-        if (isset($parallax_one_image_section_show) && $parallax_one_image_section_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_image_section');
-        endif;
-
-        $parallax_one_articles_section_show = get_theme_mod('parallax_one_articles_show', DefArticles::$hide);
-        if (isset($parallax_one_articles_section_show) && $parallax_one_articles_section_show != 1):
-          array_push($not_hidden_sections, 'sections/parallax_one_articles_section');
-        endif;
-      }
-
-      $parallax_one_contact_show = get_theme_mod('parallax_one_contact_show');
-      if (isset($parallax_one_contact_show) && $parallax_one_contact_show != 1):
-        array_push($not_hidden_sections, 'sections/parallax_one_contact_section');
-      endif;
 
       $sections_array = apply_filters("parallax_one_pro_sections_filter", $not_hidden_sections);
 

--- a/wp-content/themes/Parallax-One/inc/customizer.php
+++ b/wp-content/themes/Parallax-One/inc/customizer.php
@@ -951,7 +951,7 @@ function parallax_one_customize_register( $wp_customize ) {
         'priority' => 3,
         'fields' => array(
           'question' => array('type' => 'text', 'label' => 'Question', 'placeholder' => 'Why join 4Water?'),
-          'answer' => array('type' => 'text', 'label' => 'Answer', 'placeholder' => "It's just awesome!"),
+          'answer' => array('type' => 'textarea', 'label' => 'Answer', 'placeholder' => "It's just awesome!"),
         )
       )
     )

--- a/wp-content/themes/Parallax-One/sections/parallax_one_congress_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_congress_section.php
@@ -1,0 +1,148 @@
+<!-- =========================
+ CONGRESS - CUSTOM SECTIONS TO FILL OUT BY THE ORGANIZERS
+========================== -->
+
+<!-- 1: WHITE SECTION -->
+<section class="congress-white-section" id="congress-white-section-1">
+  <div class="section-overlay-layer">
+    <div class="container">
+      <div class="section-header">
+          <!-- HEADING -->
+          <h2 class="dark-text">CURRENCY & PRIZES</h2>
+          <!-- 1 COLUMN LAYOUT -->
+          <div class="onecolumn-wrap">
+              <div class="onecolumn-row col-md-12">
+                  <div class="onecolumn-content col-md-8">
+                    <ul>
+                        <li class="onecolumn-item">
+                          CZK: in some places they accept EUR as well, but better not count with it.
+                        </li>
+                        <li>
+                          ATM & Exchange: There are plenty of ATMs everzywhere. We recommend to exchange money before you come and once you are here to simply withdraw from ATM
+                        </li>
+                        <li>
+                          Avarage prices in the Czech Republic – link to some website with avg prices info
+                        </li>
+                    </ul>
+                  </div>
+              </div>
+          </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 2: GREY SECTION -->
+<section class="congress-grey-section" id="congress-grey-section-2">
+    <div class="section-overlay-layer">
+        <div class="container">
+            <div class="section-header">
+                <!-- HEADING -->
+                <h2 class="dark-text">TRANSPORTATION</h2>
+                <!-- 3 COLUMN LAYOUT -->
+                <div id="threecolumn-wrap">
+                    <div class="threecolumn-row col-md-12">
+                        <div class="threecolumn-box col-md-4">
+                            <h3>Public transportation in Prague</h3>
+                            <a href="http://4water.org/prague-congress">Tickets</a><br />
+                            <a href="http://4water.org/prague-congress">Bike renting</a>
+                        </div>
+                        <div class="threecolumn-box col-md-4">
+                            <h3>How to get to the hostel</h3>
+                            <a href="http://4water.org/prague-congress">From the airport</a><br />
+                            <a href="http://4water.org/prague-congress">From the train station</a><br />
+                            <a href="http://4water.org/prague-congress">From the bus station</a>
+                        </div>
+                        <div class="threecolumn-box col-md-4">
+                            <h3>How to get to the venue</h3>
+                            <a href="http://4water.org/prague-congress">From the hostel</a>
+                        </div>
+                    </div>
+                    <img src="http://4water.org/prague-congress/wp-content/uploads/sites/46/2020/03/congress-map.png" />
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- 3: BLUE SECTION -->
+<section class="congress-blue-section" id="congress-blue-section-3">
+    <div class="section-overlay-layer">
+        <div class="container">
+            <div class="section-header">
+                <!-- HEADING -->
+                <h2 class="dark-text">ACCOMMODATION</h2>
+                <!-- 1 COLUMN LAYOUT -->
+                <div class="onecolumn-wrap">
+                    <div class="onecolumn-row col-md-12">
+                        <div class="onecolumn-content col-md-8">
+                            <p>Will be arranged in:</p>
+                            <ul>
+                                <li class="onecolumn-item">
+                                    a hostel close to the venues
+                                </li>
+                                <li>
+                                    or with Prague volunteers
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="onecolumn-content col-md-8">
+                            <p>Some accommodation will be covered by D4W Prague Team resources. Participants that are willing to cover part or total accommodation cost, are welcome to do so.</p>
+                            <p>More information coming after we have complete registration list!</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- 4: WHITE SECTION -->
+<section class="congress-white-section" id="congress-white-section-4">
+    <div class="section-overlay-layer">
+        <div class="container">
+            <div class="section-header">
+                <!-- HEADING -->
+                <h2 class="dark-text">CONTACTS</h2>
+                <!-- 1 COLUMN LAYOUT -->
+                <div class="onecolumn-wrap">
+                    <div class="onecolumn-row col-md-12">
+                        <div class="onecolumn-content col-md-8">
+                            <ul>
+                                <li class="onecolumn-item">
+                                    <strong>Main:</strong> Ludovico
+                                </li>
+                                <li>
+                                    <strong>General Communication:</strong> Tomas B.
+                                </li>
+                                <li>
+                                    <strong>Program:</strong>
+                                    <ul>
+                                        <li>
+                                            <strong>Workshops:</strong> Masha
+                                        </li>
+                                        <li>
+                                            <strong>Private party:</strong> Sarah
+                                        </li>
+                                        <li>
+                                            <strong>Public party:</strong> Roza
+                                        </li>
+                                        <li>
+                                            <strong>Sunday chill:</strong> TBD
+                                        </li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <strong>Venues:</strong> Radka
+                                </li>
+                                <li>
+                                    <strong>Accommodation:</strong> Pali
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/wp-content/themes/Parallax-One/sections/parallax_one_faq_section.php
+++ b/wp-content/themes/Parallax-One/sections/parallax_one_faq_section.php
@@ -38,7 +38,9 @@
                       <?php echo $faq_item->question; ?>
                     </div>
                     <div class="faq-answer">
-                      <?php echo nl2br($faq_item->answer); ?>
+                        <p style="padding-top: 0; margin-top: 0;" class="keep-newlines">
+                            <?php echo $faq_item->answer; ?>
+                        </p>
                     </div>
                   </div>
                   <?php

--- a/wp-content/themes/Parallax-One/style.css
+++ b/wp-content/themes/Parallax-One/style.css
@@ -1526,7 +1526,7 @@ div.faq-box {
 
 div.faq-question {
 	font-weight: bold;
-	padding-bottom: 15px;
+	padding-bottom: 0px;
 }
 
 /* when faq boxes are next to each other in wider viewport */
@@ -5612,6 +5612,79 @@ p#video-caption {
 @media only screen and (max-width: 800px) {
 	section.video-section div.subtitle {
 		margin: 0 10px !important;
+	}
+}
+
+/*---------------------------------------
+   3.20 SECTION: CONGRESS
+-----------------------------------------*/
+
+section.congress-white-section {
+	background-color: white;
+}
+
+section.congress-grey-section {
+	background-color: #f7f8fa;
+}
+
+section.congress-blue-section {
+	background-color: #3a98cb;
+	color: white;
+}
+
+section.congress-blue-section .section-header h2 {
+	color: white;
+}
+
+.onecolumn-wrap {
+	padding: 40px 2% 30px 2%;
+	margin: 0 auto;
+	text-align: center;
+}
+
+.onecolumn-content {
+	text-align: left;
+	padding: 0 30px;
+	display: inline-block;
+	float: none !important;
+}
+
+.onecolumn-item {
+	padding-bottom: 10px;
+	text-align: left;
+}
+
+.threecolumn-wrap {
+	padding: 40px 2% 30px 2%;
+	margin: 0 auto;
+	text-align: center;
+}
+
+.threecolumn-box {
+	text-align: center;
+	padding: 0 30px;
+}
+
+.threecolumn-box h3 {
+	font-size: 21px;
+	color: #444;
+}
+
+.onecolumn-row {
+	width: 100%;
+}
+
+.threecolumn-row {
+	width: 100%;
+}
+
+/* when boxes are next to each other in wider viewport */
+
+@media (min-width: 992px) {
+	.threecolumn-box {
+		margin-bottom: 0px;
+		padding-top: 10px;
+		padding-bottom: 10px;
 	}
 }
 


### PR DESCRIPTION
This PR contains mostly congress-related changes.
![image](https://user-images.githubusercontent.com/2544475/75724461-bb1daa00-5cde-11ea-912a-23844f26a775.png)

With Radka from Prague we're in the midst of creating an information page about the congress. The aim is to create sections that are editable and reusable for future congresses.

The main pain-point of our current WP template is, that there was no way to add custom structured text, common in any word processor software (custom headings and subheadings, bullet points, hyperlinks), as our template dictated the layout. For congress, the only sections that can be reused 100% are Introduction, FAQ, Contacts, Maps, and maybe few other sections. This will add a possibility to add up to 4 sections with some common structured text, e.g. like this:
![image](https://user-images.githubusercontent.com/2544475/75724855-8bbb6d00-5cdf-11ea-9fd6-a9e044e6458d.png)

**Work in progress**

* also includes an improvement to FAQ section's answers (textarea with newlines)